### PR TITLE
doc: add copyright headers to Frost module

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,5 @@
 Copyright (c) 2013 Pieter Wuille
+Copyright (c) 2023 Bank of Italy (Frost module)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ secp256k1-frost
 This repository extends the [secp256k1](https://github.com/bitcoin-core/secp256k1) library to implement FROST,
 a Schnorr threshold signature scheme originally designed by C. Komlo and I. Goldberg.
 
-The codebase of secp256k1-frost is a fork of the [secp256k1](https://github.com/bitcoin-core/secp256k1) repository.
+The codebase of secp256k1-frost is a fork of the [secp256k1](https://github.com/bitcoin-core/secp256k1)
+repository and was originally developed by Bank of Italy as part of the [itcoin project](https://bancaditalia.github.io/itcoin/).
 
 You can find more information about `secp256k1-frost` in the [dedicated README.md](./src/modules/frost/README.md) file.
 

--- a/include/secp256k1_frost.h
+++ b/include/secp256k1_frost.h
@@ -1,3 +1,9 @@
+/***********************************************************************
+ * Copyright (c) 2023 Bank of Italy                                    *
+ * Distributed under the MIT software license, see the accompanying    *
+ * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
+ ***********************************************************************/
+
 #ifndef SECP256K1_FROST_H
 #define SECP256K1_FROST_H
 

--- a/src/modules/frost/README.md
+++ b/src/modules/frost/README.md
@@ -13,6 +13,8 @@ the [Cryptology ePrint Archive (Paper 2020/852)](https://eprint.iacr.org/2020/85
 
 Currently, FROST is undergoing an IETF standardization process ([status](https://datatracker.ietf.org/doc/draft-irtf-cfrg-frost/)).
 
+This module was originally developed by Bank of Italy as part of the [itcoin project](https://bancaditalia.github.io/itcoin/).
+
 ## Build
 
 FROST is implemented as a module of the secp256k1 library. Currently, it is an experimental module.

--- a/src/modules/frost/main_impl.h
+++ b/src/modules/frost/main_impl.h
@@ -1,3 +1,9 @@
+/***********************************************************************
+ * Copyright (c) 2023 Bank of Italy                                    *
+ * Distributed under the MIT software license, see the accompanying    *
+ * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
+ ***********************************************************************/
+
 #ifndef SECP256K1_MODULE_FROST_MAIN_H
 #define SECP256K1_MODULE_FROST_MAIN_H
 

--- a/src/modules/frost/tests_impl.h
+++ b/src/modules/frost/tests_impl.h
@@ -1,3 +1,9 @@
+/***********************************************************************
+ * Copyright (c) 2023 Bank of Italy                                    *
+ * Distributed under the MIT software license, see the accompanying    *
+ * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
+ ***********************************************************************/
+
 #ifndef SECP256K1_MODULE_FROST_TESTS_H
 #define SECP256K1_MODULE_FROST_TESTS_H
 


### PR DESCRIPTION
This PR:

- adds a copyright header in the frost module, in line with what already exists - for example - for the `schnorrsig` module:
  https://github.com/bitcoin-core/secp256k1/blob/5b32602295ff7ad9e1973f96b8ee8344b82f4af0/src/modules/schnorrsig/main_impl.h#L1-L5
  This is the header that gets added:

  ```
  /***********************************************************************
   * Copyright (c) 2023 Bank of Italy                                    *
   * Distributed under the MIT software license, see the accompanying    *
   * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
   ***********************************************************************/
  ```

- modifies the READMEs to mention that the original author of the Frost module is Bank of Italy.

