### PR TITLE
Remove potential memory leak in secp256k1_frost_aggregate()

### DIFF
--- a/src/modules/frost/main_impl.h
+++ b/src/modules/frost/main_impl.h
@@ -1401,6 +1401,7 @@ SECP256K1_API int secp256k1_frost_aggregate(const secp256k1_context *ctx,
 
     /* Compute the binding factor(s) */
     if (compute_binding_factors(&binding_factors, msg32, 32, num_signers, commitments) == 0) {
+        free_binding_factors(&binding_factors);
         return 0;
     }
 


### PR DESCRIPTION
The leak presented if `compute_binding_factors()` failed. In that case the error reporting path would not deallocate the binding factors that were allocated just above.

Found with gcc 13.1 via:
```
./configure SECP_CFLAGS="-fanalyzer -fanalyzer-transitivity" --disable-tests --disable-exhaustive-tests --disable-benchmark --enable-experimental --enable-module-frost
```

The analyzer found 3 leaks at `main_impl.h:1403`, all of them solved by this change.
A simplified branch analysis of the first one was the following:

```
In file included from src/secp256k1.c:767:
src/modules/frost/main_impl.h: In function 'secp256k1_frost_aggregate':
src/modules/frost/main_impl.h:1454:1: warning: leak of 'binding_factors.binding_factors' [CWE-401] [-Wanalyzer-malloc-leak]
 1454 | }
      | ^
  'secp256k1_frost_aggregate': events 1-2
    |
    | 1365 | SECP256K1_API int secp256k1_frost_aggregate(const secp256k1_context *ctx,
    |      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~
    |      |                   |
    |      |                   (1) entry to 'secp256k1_frost_aggregate'
    [...]
    | 1394 |     binding_factors.binding_factors = (secp256k1_scalar *)
    | 1395 |             checked_malloc(&default_error_callback, num_signers * sizeof(secp256k1_scalar));
    |      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |             |
    |      |             (10) calling 'checked_malloc' from 'secp256k1_frost_aggregate'
    |
    +--> 'checked_malloc': events 11-15
           |
           |src/util.h:118:31:
           |  118 | static SECP256K1_INLINE void *checked_malloc(const secp256k1_callback* cb, size_t size) {
           |      |                               ^~~~~~~~~~~~~~
           |      |                               |
           |      |                               (11) entry to 'checked_malloc'
           |  119 |     void *ret = malloc(size);
           |      |                 ~~~~~~~~~~~~
           |      |                 |
           |      |                 (12) allocated here
  [...]
  'secp256k1_frost_aggregate': events 29-30
    |
    | 1403 |     if (compute_binding_factors(&binding_factors, msg32, 32, num_signers, commitments) == 0) {
    |      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |         |
    |      |         (29) ...to here
    |......
    | 1454 | }
    |      | ~
    |      | |
    |      | (30) 'binding_factors.binding_factors' leaks here; was allocated at (12)
    |
```
