### PR TITLE
Missing error check in deserialize_frost_signature() could lead to UB in secp256k1_frost_verify()

### DIFF
--- a/src/modules/frost/main_impl.h
+++ b/src/modules/frost/main_impl.h
@@ -122,7 +122,9 @@ static SECP256K1_WARN_UNUSED_RESULT int deserialize_frost_signature(secp256k1_fr
     secp256k1_fe x;
     secp256k1_ge deserialized_point;
     secp256k1_fe_set_b32(&x, serialized_signature);
-    secp256k1_ge_set_xo_var(&deserialized_point, &x, 0);
+    if (secp256k1_ge_set_xo_var(&deserialized_point, &x, 0) == 0) {
+        return 0;
+    }
     secp256k1_gej_set_ge(&(signature->r), &deserialized_point);
     if (convert_b32_to_scalar(&serialized_signature[SERIALIZED_PUBKEY_X_ONLY_SIZE], &(signature->z)) == 0) {
         return 0;


### PR DESCRIPTION
The upstream function `secp256k1_ge_set_xo_var()` in `src/group_impl.h` returns an int signalling an error condition, but it is not marked with `SECP256K1_WARN_UNUSED_RESULT`.
Thus, when compiling the Frost module, no warning was generated when `deserialize_frost_signature()` did not check the return value of that function.

The gcc static analyzer found two potential execution paths in `secp256k1_frost_verify()` that would lead to undefined behaviour.

As of today (2023-05-29), in bitcoin-core secp256k1, secp256k1_ge_set_xo_var() is still not marked `SECP256K1_WARN_UNUSED_RESULT`, see: https://github.com/bitcoin-core/secp256k1/blob/908e02d596b66203788e8945b1f9c93ff28a4536/src/group_impl.h#L280. **It may make sense to propose upstream to add that annotation**.


In order to replicate the issues fixed by this commit, compile with:
```
./configure SECP_CFLAGS="-fanalyzer -fanalyzer-transitivity" --disable-tests --disable-exhaustive-tests --disable-benchmark --enable-experimental --enable-module-frost
```
