### PR TITLE
frost: initialize point as infinity instead of invalid

### DIFF
--- a/src/modules/frost/main_impl.h
+++ b/src/modules/frost/main_impl.h
@@ -53,6 +53,10 @@ static void secp256k1_ge_set_gej_safe(secp256k1_ge *r, const secp256k1_gej *a) {
 
 static void secp256k1_gej_mul_scalar(secp256k1_gej *result, const secp256k1_gej *pt, const secp256k1_scalar *sc) {
     secp256k1_ge pt_ge;
+    if (secp256k1_gej_is_infinity(pt)) {
+        secp256k1_gej_set_infinity(result);
+        return;
+    }
     secp256k1_ge_set_gej_safe(&pt_ge, pt);
     secp256k1_ecmult_const(result, &pt_ge, sc, ECMULT_CONST_256_BIT_SIZE);
 }

--- a/src/modules/frost/main_impl.h
+++ b/src/modules/frost/main_impl.h
@@ -719,7 +719,7 @@ static SECP256K1_WARN_UNUSED_RESULT int verify_secret_share(const secp256k1_cont
 
     secp256k1_scalar_set_int(&x, share->receiver_index);
     secp256k1_scalar_set_int(&x_to_the_i, 1);
-    secp256k1_gej_clear(&result);
+    secp256k1_gej_set_infinity(&result);
     secp256k1_gej_mul_scalar(&result, &result, &x_to_the_i);
 
     for (index = 0; index < commitment->num_coefficients; index++) {
@@ -768,7 +768,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_frost_keygen_dkg_finali
     secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &pubkey, &scalar_secret);
     serialize_point(&pubkey, keypair->public_keys.public_key);
 
-    secp256k1_gej_clear(&group_pubkey);
+    secp256k1_gej_set_infinity(&group_pubkey);
     secp256k1_scalar_set_int(&scalar_unit, 1);
     secp256k1_gej_mul_scalar(&group_pubkey,
                              &group_pubkey, &scalar_unit);
@@ -897,7 +897,7 @@ static SECP256K1_WARN_UNUSED_RESULT int compute_group_commitment(/* out */ secp2
     uint32_t index, inner_index;
 
     secp256k1_scalar_set_int(&scalar_unit, 1);
-    secp256k1_gej_clear(group_commitment);
+    secp256k1_gej_set_infinity(group_commitment);
     secp256k1_gej_mul_scalar(group_commitment, group_commitment, &scalar_unit);
 
     for (index = 0; index < num_signers; index++) {
@@ -919,7 +919,7 @@ static SECP256K1_WARN_UNUSED_RESULT int compute_group_commitment(/* out */ secp2
             return 0;
         }
 
-        secp256k1_gej_clear(&partial);
+        secp256k1_gej_set_infinity(&partial);
         secp256k1_gej_mul_scalar(&partial, &partial, &scalar_unit);
 
         /* group_commitment += commitment.d + (commitment.e * rho_i) */

--- a/src/modules/frost/tests_impl.h
+++ b/src/modules/frost/tests_impl.h
@@ -567,7 +567,7 @@ void test_secp256k1_frost_keygen_validate_invalid_secret_commitment(void) {
     secp256k1_context *sign_ctx;
     secp256k1_frost_vss_commitments *dkg_commitment;
     secp256k1_frost_keygen_secret_share shares[3];
-    secp256k1_gej _identityPoint;
+    secp256k1_gej _invalidPoint;
     int result;
     const unsigned char context[4] = "test";
     const uint32_t threshold = 2;
@@ -581,8 +581,8 @@ void test_secp256k1_frost_keygen_validate_invalid_secret_commitment(void) {
     CHECK(result == 1);
 
     /* now, set the first commitments to be invalid */
-    secp256k1_gej_clear(&_identityPoint);
-    serialize_point(&_identityPoint, dkg_commitment->coefficient_commitments[0].data);
+    secp256k1_gej_clear(&_invalidPoint);
+    serialize_point(&_invalidPoint, dkg_commitment->coefficient_commitments[0].data);
 
     /* now, ensure that this dkg commitment is marked as invalid */
     result = secp256k1_frost_keygen_dkg_commitment_validate(
@@ -925,7 +925,7 @@ void test_secp256k1_frost_keygen_finalize_invalid_commitments(void) {
     secp256k1_frost_keypair keypair;
     uint32_t index;
     const unsigned char context[4] = "test";
-    secp256k1_gej _identityPoint;
+    secp256k1_gej _invalidPoint;
 
     /* Step 1. initialization */
     num_participants = 3;
@@ -956,8 +956,8 @@ void test_secp256k1_frost_keygen_finalize_invalid_commitments(void) {
     }
 
     /* now, set the first commitments to be invalid */
-    secp256k1_gej_clear(&_identityPoint);
-    serialize_point(&_identityPoint, dkg_commitment[0]->coefficient_commitments[0].data);
+    secp256k1_gej_clear(&_invalidPoint);
+    serialize_point(&_invalidPoint, dkg_commitment[0]->coefficient_commitments[0].data);
 
     /* Step 4. keygen finalize for each participant */
     for (index = 0; index < num_participants; index++) {


### PR DESCRIPTION
Initialize gej points as points to infinity, instead of using invalid values. 