### PR TITLE
Mention frost in the pkg-config description of the library. Link to Bank of Italy's github fork

### DIFF
--- a/libsecp256k1.pc.in
+++ b/libsecp256k1.pc.in
@@ -4,8 +4,8 @@ libdir=@libdir@
 includedir=@includedir@
 
 Name: libsecp256k1
-Description: Optimized C library for EC operations on curve secp256k1
-URL: https://github.com/bitcoin-core/secp256k1
+Description: Optimized C library for EC operations on curve secp256k1, with support for FROST signature scheme # FROST_SPECIFIC
+URL: https://github.com/bancaditalia/secp256k1-frost # FROST_SPECIFIC
 Version: @PACKAGE_VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lsecp256k1


### PR DESCRIPTION
A reference per the pkg-config sytax can be found in "man 5 pc", or online at https://man.freebsd.org/cgi/man.cgi?query=pc&sektion=5&n=1

```
EXAMPLES
     An example .pc file:

     # This is a comment
     prefix=/home/kaniini/pkg   # this defines a variable
     exec_prefix=${prefix}      # defining another variable with a substitution
     libdir=${exec_prefix}/lib
     includedir=${prefix}/include

     Name: libfoo                                  # human-readable name
     Description: an example library called libfoo # human-readable description
     Version: 1.0
     URL: http://www.pkgconf.org
     Requires: libbar > 2.0.0
     Conflicts: libbaz <= 3.0.0
     Libs: -L${libdir} -lfoo
     Libs.private: -lm
     Cflags: -I${includedir}/libfoo
```