### PR TITLE
frost: use parentheses around argument of sizeof()

### DIFF
--- a/src/modules/frost/main_impl.h
+++ b/src/modules/frost/main_impl.h
@@ -178,7 +178,7 @@ static void compute_hash_h1(const unsigned char *msg, uint32_t msg_len, unsigned
     unsigned char prefix[26 + 3];
     memcpy(prefix, hash_context_prefix, 26);
     memcpy(prefix + 26, "rho", 3);
-    compute_hash_with_prefix(prefix, sizeof prefix, msg, msg_len, hash_value);
+    compute_hash_with_prefix(prefix, sizeof(prefix), msg, msg_len, hash_value);
 }
 
 static void compute_hash_h2(const unsigned char *msg, uint32_t msg_len, unsigned char *hash_value) {
@@ -186,7 +186,7 @@ static void compute_hash_h2(const unsigned char *msg, uint32_t msg_len, unsigned
     * H2(m): Implemented using hash_to_field from [HASH-TO-CURVE], Section 5.2 using L = 48,
     * expand_message_xmd with SHA-256, DST = contextString || "chal", and prime modulus equal to Order().*/
     const unsigned char prefix[17] = "BIP0340/challenge";
-    compute_hash_with_prefix(prefix, sizeof prefix, msg, msg_len, hash_value);
+    compute_hash_with_prefix(prefix, sizeof(prefix), msg, msg_len, hash_value);
 }
 
 static void compute_hash_h3(const unsigned char *msg, uint32_t msg_len, unsigned char *hash_value) {
@@ -196,7 +196,7 @@ static void compute_hash_h3(const unsigned char *msg, uint32_t msg_len, unsigned
     unsigned char prefix[26 + 5];
     memcpy(prefix, hash_context_prefix, 26);
     memcpy(prefix + 26, "nonce", 5);
-    compute_hash_with_prefix(prefix, sizeof prefix, msg, msg_len, hash_value);
+    compute_hash_with_prefix(prefix, sizeof(prefix), msg, msg_len, hash_value);
 }
 
 static void compute_hash_h4(const unsigned char *msg, uint32_t msg_len, unsigned char *hash_value) {
@@ -204,7 +204,7 @@ static void compute_hash_h4(const unsigned char *msg, uint32_t msg_len, unsigned
     unsigned char prefix[26 + 3];
     memcpy(prefix, hash_context_prefix, 26);
     memcpy(prefix + 26, "msg", 3);
-    compute_hash_with_prefix(prefix, sizeof prefix, msg, msg_len, hash_value);
+    compute_hash_with_prefix(prefix, sizeof(prefix), msg, msg_len, hash_value);
 }
 
 static void compute_hash_h5(const unsigned char *msg, uint32_t msg_len, unsigned char *hash_value) {
@@ -212,7 +212,7 @@ static void compute_hash_h5(const unsigned char *msg, uint32_t msg_len, unsigned
     unsigned char prefix[26 + 3];
     memcpy(prefix, hash_context_prefix, 26);
     memcpy(prefix + 26, "com", 3);
-    compute_hash_with_prefix(prefix, sizeof prefix, msg, msg_len, hash_value);
+    compute_hash_with_prefix(prefix, sizeof(prefix), msg, msg_len, hash_value);
 }
 
 static void nonce_generate(unsigned char *out32, const secp256k1_frost_keypair *keypair,


### PR DESCRIPTION
As per C89 standard (https://www.open-std.org/JTC1/sc22/wg14/www/docs/n1256.pdf, section 6.5.3 "Unary operators") we are only required to parenthesize a `sizeof()` call if the argument is a type name, which is not the case here:

```
sizeof unary-expression
sizeof ( type-name )
```

However, it is less surprising to err on the side of caution, and uniformly enclose in parentheses every `sizeof()` invocation across the code base.

No functional changes.
