### PR TITLE
doc: add badge with the status of the last CI run on frost branch

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -1,4 +1,5 @@
-name: Execute tests with coverage enabled (gcc13)
+name: Functional tests, gcc13
+
 # In secp256k1 some assertions are not exactly equal when coverage is enabled
 # and when it is not. Hence, it is better to run the two cases separately.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 secp256k1-frost
 =====================================
 
+[![tests](https://github.com/bancaditalia/secp256k1-frost/actions/workflows/functional-tests.yml/badge.svg?branch=frost&event=push)](https://github.com/bancaditalia/secp256k1-frost/actions/workflows/functional-tests.yml)
+
 This repository extends the [secp256k1](https://github.com/bitcoin-core/secp256k1) library to implement FROST,
 a Schnorr threshold signature scheme originally designed by C. Komlo and I. Goldberg.
 


### PR DESCRIPTION
The updated README after merging this PR can be seen at https://github.com/bancaditalia/secp256k1-frost/blob/add-badge/README.md.

Sample:
![image](https://github.com/bancaditalia/secp256k1-frost/assets/4067621/c770aca6-8adb-4a18-a775-c28b91670ed7)
