### PR TITLE
ci: check version consistency between autotools and cmake

### DIFF
--- a/.github/workflows/verify-version-consistency.yml
+++ b/.github/workflows/verify-version-consistency.yml
@@ -1,0 +1,19 @@
+name: Check that the version numbers contained in configure.ac and CMakeLists.txt are consistent to each other
+
+on:
+  push:
+    branches:
+      - frost
+  pull_request:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  verify-version-consistency:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Check that the version numbers contained in configure.ac and CMakeLists.txt are consistent to each other
+        run: scripts/verify-version-consistency.sh

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,2 @@
+This directory contains custom scripts for the itcoin project secp256k1-frost.
+It is not part of https://github.com/bitcoin-core/secp256k1

--- a/scripts/verify-version-consistency.sh
+++ b/scripts/verify-version-consistency.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+set -u
+set -o errtrace
+set -o pipefail
+
+# source: https://stackoverflow.com/questions/59895/how-do-i-get-the-directory-where-a-bash-script-is-located-from-within-the-script/246128#246128
+MY_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+BASE_DIR=$(realpath "${MY_DIR}/..")
+CONFIGURE_AC=$(realpath --canonicalize-existing "${MY_DIR}/../configure.ac")
+BUILD_DIR=$(mktemp --tmpdir --directory secp256k1-frost-build.XXXX)
+
+errecho() {
+    # prints to stderr
+    >&2 echo "${@}"
+}
+
+handle_error() {
+    local EXIT_CODE
+    EXIT_CODE=$1 && shift
+    errecho "ERROR: exiting on unexpected error ${EXIT_CODE}"
+    exit "${EXIT_CODE}"
+}
+
+trap 'handle_error $?' ERR
+
+check_prerequisites() {
+    if ! command -v cmake &> /dev/null; then
+        errecho "Please install cmake"
+        exit 1
+    fi
+    if ! command -v gawk &> /dev/null; then
+        errecho "Please install gawk"
+        exit 1
+    fi
+    if ! command -v realpath &> /dev/null; then
+        errecho "The realpath command is not available"
+        exit 1
+    fi
+}
+
+extract_from_configure_ac() {
+    # $1: variable part of the regex defining the field to be matched
+    # $2: if true, also require that the extracted string is a number
+    #
+    # Reads the global variable CONFIGURE_AC and interprets it as a file name.
+    local EXTRACTED_NUMBER
+    local REQUIRE_NUMERIC_FORMAT
+    EXTRACTED_NUMBER=$(gawk "match(\$0, /define\(${1}, ([^\)]*)\)/, a) { print a[1] }" "${CONFIGURE_AC}")
+    REQUIRE_NUMERIC_FORMAT="${2:-true}"
+    if [[ "${REQUIRE_NUMERIC_FORMAT}" == true ]] && ! [[ "${EXTRACTED_NUMBER}" =~ ^[0-9]+$ ]]; then
+        errecho "ERROR: could not extract field $1 from ${CONFIGURE_AC}. The value that was found (\"${EXTRACTED_NUMBER}\") is not a number"
+        exit 1
+    fi
+    echo "${EXTRACTED_NUMBER}"
+}
+
+extract_from_cmake() {
+    # $1: variable part of the regex defining the field to be matched
+    # $2: if true, also require that the extracted string is a number
+    #
+    # Reads the global variable SYSTEM_INFORMATION and use it as the text to
+    # search into.
+    local EXTRACTED_NUMBER
+    local REQUIRE_NUMERIC_FORMAT
+    EXTRACTED_NUMBER=$(gawk -F= "\$1~/$1/{print\$2}" - <<<"${SYSTEM_INFORMATION}")
+    REQUIRE_NUMERIC_FORMAT="${2:-true}"
+    if [[ "${REQUIRE_NUMERIC_FORMAT}" == true ]] && ! [[ "${EXTRACTED_NUMBER}" =~ ^[0-9]+$ ]]; then
+        errecho "ERROR: could not extract field $1 from ${BUILD_DIR}/CMakeCache.txt. The value that was found (\"${EXTRACTED_NUMBER}\") is not a number. Check your CMakeLists.txt"
+        exit 1
+    fi
+    echo "${EXTRACTED_NUMBER}"
+}
+
+check_equal() {
+    # $1: version in configure.ac
+    # $2: version in CMakeLists.txt
+    # $3: human-friendly field name (e.g., "MAJOR_VERSION") to use in the
+    #     eventual error message
+    if [[ "${1}" != "${2}" ]]; then
+        errecho "ERROR: field \"${3}\" in configure.ac (\"${1}\") is different than the one in CMakeLists.txt (\"${2}\")"
+        exit 1
+    fi
+}
+
+check_prerequisites
+
+# gather data from configure.ac
+AC_VERSION_MAJOR=$(extract_from_configure_ac _PKG_VERSION_MAJOR)
+AC_VERSION_MINOR=$(extract_from_configure_ac _PKG_VERSION_MINOR)
+AC_VERSION_PATCH=$(extract_from_configure_ac _PKG_VERSION_PATCH)
+AC_VERSION_FROST=$(extract_from_configure_ac _PKG_VERSION_FROST_BUILD)
+AC_VERSION_FULL="${AC_VERSION_MAJOR}.${AC_VERSION_MINOR}.${AC_VERSION_PATCH}.${AC_VERSION_FROST}"
+errecho "INFO: version found in configure.ac: is \"${AC_VERSION_FULL}\""
+
+# gather data from CMakeLists.txt
+cmake --log-level=error -S "${BASE_DIR}" -B "${BUILD_DIR}" >/dev/null
+# shellcheck disable=SC2164
+pushd "${BUILD_DIR}" >/dev/null
+SYSTEM_INFORMATION=$(cmake --system-information -N)
+# shellcheck disable=SC2164
+popd >/dev/null
+
+CMAKE_PROJECT_VERSION_MAJOR=$(extract_from_cmake "CMAKE_PROJECT_VERSION_MAJOR:STATIC")
+CMAKE_PROJECT_VERSION_MINOR=$(extract_from_cmake "CMAKE_PROJECT_VERSION_MINOR:STATIC")
+CMAKE_PROJECT_VERSION_PATCH=$(extract_from_cmake "CMAKE_PROJECT_VERSION_PATCH:STATIC")
+CMAKE_PROJECT_VERSION_TWEAK=$(extract_from_cmake "CMAKE_PROJECT_VERSION_TWEAK:STATIC")
+CMAKE_PROJECT_VERSION=$(extract_from_cmake "CMAKE_PROJECT_VERSION:STATIC" false)
+errecho "INFO: version found in CMakeLists.txt: is \"${CMAKE_PROJECT_VERSION}\""
+
+# check that configure.ac and CMakeLists.txt contain the same information
+check_equal "${AC_VERSION_MAJOR}" "${CMAKE_PROJECT_VERSION_MAJOR}" "major version"
+check_equal "${AC_VERSION_MINOR}" "${CMAKE_PROJECT_VERSION_MINOR}" "minor version"
+check_equal "${AC_VERSION_PATCH}" "${CMAKE_PROJECT_VERSION_PATCH}" "patch version"
+check_equal "${AC_VERSION_FROST}" "${CMAKE_PROJECT_VERSION_TWEAK}" "frost version"
+check_equal "${AC_VERSION_FULL}" "${CMAKE_PROJECT_VERSION}" "full frost version"
+
+echo "SUCCESS: identified version ${AC_VERSION_FULL}"


### PR DESCRIPTION
Our project version number is structured as following: `major.minor.patch-itcoin-frost-build` (for example: `0.3.0-frost-1`).

secp256k1 **v0.3.0** introduced support for building via CMake. In the process, it also duplicated the places where the version information is stored: no longer just `configure.ac`, but also `CMakeLists.txt`.

We now have to ensure that the two files are in sync. Additionally, we have to do the same check for the frost-specific version number.

The PR introduces a script that takes care of this and integrates the check in the CI.
