### PR TITLE
ci: update "actions/checkout@v3" -> "actions/checkout@v4"

### DIFF
--- a/.github/workflows/build-with-cmake.yml
+++ b/.github/workflows/build-with-cmake.yml
@@ -20,7 +20,7 @@ jobs:
           dnf install -y \
               cmake \
               gcc
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Build with CMake

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -27,7 +27,7 @@ jobs:
               gcovr \
               libtool \
               pkg-config
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Run autogen

--- a/.github/workflows/tests-and-examples-under-valgrind.yml
+++ b/.github/workflows/tests-and-examples-under-valgrind.yml
@@ -24,7 +24,7 @@ jobs:
               libtool \
               pkg-config \
               valgrind
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: prepare the build (only enabling FROST, tests and examples)


### PR DESCRIPTION
Workflow `verify-version-consistency` was the last one written, and already used checkout@v4.

Let's align all the remaining workflows to use [the most recent action version](https://github.com/actions/checkout).

No functional changes.