### PR TITLE
ci: update runners (ubuntu 22.04 -> 24.04)

### DIFF
--- a/.github/workflows/build-with-cmake.yml
+++ b/.github/workflows/build-with-cmake.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-with-cmake:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # Use fedora:39 to compile using gcc-13.2
     container:
       image: fedora:39

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   functional-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # Use fedora:39 to compile using gcc-13.2
     container:
       image: fedora:39

--- a/.github/workflows/tests-and-examples-under-valgrind.yml
+++ b/.github/workflows/tests-and-examples-under-valgrind.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   tests-and-examples-under-valgrind:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # Use fedora:39 to compile using gcc-13.2
     container:
       image: fedora:39

--- a/.github/workflows/verify-version-consistency.yml
+++ b/.github/workflows/verify-version-consistency.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   verify-version-consistency:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/verify-version-consistency.yml
+++ b/.github/workflows/verify-version-consistency.yml
@@ -1,4 +1,4 @@
-name: Check that the version numbers contained in configure.ac and CMakeLists.txt are consistent to each other
+name: Check that the version numbers contained in configure.ac and CMakeLists.txt are consistent with each other
 
 on:
   push:
@@ -15,5 +15,5 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Check that the version numbers contained in configure.ac and CMakeLists.txt are consistent to each other
+      - name: Check that the version numbers contained in configure.ac and CMakeLists.txt are consistent with each other
         run: scripts/verify-version-consistency.sh


### PR DESCRIPTION
This should be a very low risk change, since the only CI job that directly uses the base image is [verify-version-consistency.yml](https://github.com/bancaditalia/secp256k1-frost/blob/838792f9bdc8c2bfc4efa55e6c5fa42dabc0c284/.github/workflows/verify-version-consistency.yml), which only depends on bash.

All the other workflows run in containers and should be unaffected; we will update the base image in the next PR.

List of installed software on the two platforms, in order to see the changes:
- https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
- https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md