### PR TITLE
ci: update base image "fedora:39" -> "fedora:41"

### DIFF
--- a/.github/workflows/build-with-cmake.yml
+++ b/.github/workflows/build-with-cmake.yml
@@ -11,9 +11,9 @@ on:
 jobs:
   build-with-cmake:
     runs-on: ubuntu-24.04
-    # Use fedora:39 to compile using gcc-13.2
+    # Use fedora:41 to compile using gcc-14.2
     container:
-      image: fedora:39
+      image: fedora:41
     steps:
       - name: Install build dependencies
         run: |

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -14,9 +14,9 @@ on:
 jobs:
   functional-tests:
     runs-on: ubuntu-24.04
-    # Use fedora:39 to compile using gcc-13.2
+    # Use fedora:41 to compile using gcc-14.2
     container:
-      image: fedora:39
+      image: fedora:41
     steps:
       - name: Install build dependencies
         run: |

--- a/.github/workflows/tests-and-examples-under-valgrind.yml
+++ b/.github/workflows/tests-and-examples-under-valgrind.yml
@@ -11,9 +11,9 @@ on:
 jobs:
   tests-and-examples-under-valgrind:
     runs-on: ubuntu-24.04
-    # Use fedora:39 to compile using gcc-13.2
+    # Use fedora:41 to compile using gcc-14.2
     container:
-      image: fedora:39
+      image: fedora:41
     steps:
       - name: Install build dependencies and Valgrind
         run: |


### PR DESCRIPTION
gcc version is now 13.2.x.
