### PR TITLE
build: add back configure.ac change that was left out when integrating v0.3.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -406,7 +406,7 @@ fi
 
 # FROST_SPECIFIC - START
 if test x"$enable_module_frost" = x"yes"; then
-  AC_DEFINE(ENABLE_MODULE_FROST, 1, [Define this symbol to enable the FROST module])
+  SECP_CONFIG_DEFINES="$SECP_CONFIG_DEFINES -DENABLE_MODULE_FROST=1"
   enable_module_frost=yes
 fi
 # FROST_SPECIFIC - END


### PR DESCRIPTION
**v0.3.0** slightly modified the way modules are enabled in `configure.ac`.

We integrated **v0.3.0** into frost on 2023-11-21, with b701c4abaf0e, but we forgot to make our `FROST_SPECIFIC` code in `configure.ac` conformant to the new convention.

We do it now.

This is not a breaking change: both old and new version should still be correct.