### PR TITLE
frost: use constant instead of allocating a variable on the stack

### DIFF
--- a/src/modules/frost/main_impl.h
+++ b/src/modules/frost/main_impl.h
@@ -881,13 +881,11 @@ static SECP256K1_WARN_UNUSED_RESULT int compute_group_commitment(/* out */ secp2
                                                                            uint32_t num_signers,
                                                                            const secp256k1_frost_binding_factors *binding_factors,
                                                                            const secp256k1_frost_nonce_commitment *signing_commitments) {
-    secp256k1_scalar scalar_unit;
     secp256k1_gej hiding_cmt, binding_cmt;
     uint32_t index, inner_index;
 
-    secp256k1_scalar_set_int(&scalar_unit, 1);
     secp256k1_gej_set_infinity(group_commitment);
-    secp256k1_gej_mul_scalar(group_commitment, group_commitment, &scalar_unit);
+    secp256k1_gej_mul_scalar(group_commitment, group_commitment, &secp256k1_scalar_one);
 
     for (index = 0; index < num_signers; index++) {
         secp256k1_scalar *rho_i;
@@ -909,7 +907,7 @@ static SECP256K1_WARN_UNUSED_RESULT int compute_group_commitment(/* out */ secp2
         }
 
         secp256k1_gej_set_infinity(&partial);
-        secp256k1_gej_mul_scalar(&partial, &partial, &scalar_unit);
+        secp256k1_gej_mul_scalar(&partial, &partial, &secp256k1_scalar_one);
 
         /* group_commitment += commitment.d + (commitment.e * rho_i) */
         deserialize_point(&hiding_cmt, commitment->hiding);

--- a/src/modules/frost/main_impl.h
+++ b/src/modules/frost/main_impl.h
@@ -730,7 +730,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_frost_keygen_dkg_finali
         const secp256k1_frost_keygen_secret_share *shares,
         secp256k1_frost_vss_commitments **commitments) {
     uint32_t s_idx, c_idx;
-    secp256k1_scalar scalar_unit, scalar_secret;
+    secp256k1_scalar scalar_secret;
     secp256k1_gej pubkey, group_pubkey;
 
     if (ctx == NULL || keypair == NULL || shares == NULL || commitments == NULL) {
@@ -759,9 +759,8 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_frost_keygen_dkg_finali
     serialize_point(&pubkey, keypair->public_keys.public_key);
 
     secp256k1_gej_set_infinity(&group_pubkey);
-    secp256k1_scalar_set_int(&scalar_unit, 1);
     secp256k1_gej_mul_scalar(&group_pubkey,
-                             &group_pubkey, &scalar_unit);
+                             &group_pubkey, &secp256k1_scalar_one);
 
     for (c_idx = 0; c_idx < num_participants; c_idx++) {
         secp256k1_gej secret_commitment;


### PR DESCRIPTION
In `compute_group_commitment()` and `secp256k1_frost_keygen_dkg_finalize()` we were allocating a variable on the stack (`scalar_unit`) just to set it at 1 later on.
For that purpose, secp256k1 already offers the constant `secp256k1_scalar_one`.

This PR gets rid of the local variables `scalar_unit`, and shortens the code.

Inspired by:
- 654246c63585 ("refactor: take use of `secp256k1_scalar_{zero,one}` constants")
- a1bd4971d6c6 ("refactor: take use of `secp256k1_scalar_{zero,one}` constants (part 2)")
