### PR TITLE
frost: use secp256k1_scalar_clear() in secp256k1_frost_keygen_dkg_begin()

### DIFF
--- a/src/modules/frost/main_impl.h
+++ b/src/modules/frost/main_impl.h
@@ -670,8 +670,8 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_frost_keygen_dkg_begin(
     secp256k1_scalar_get_b32(dkg_commitment->zkp_z, &z);
 
     /* Cleaning context */
-    secp256k1_scalar_set_int(&secret, 0);
-    secp256k1_scalar_set_int(&r, 0);
+    secp256k1_scalar_clear(&secret);
+    secp256k1_scalar_clear(&r);
     return 1;
 }
 


### PR DESCRIPTION
Before returning, `secp256k1_frost_keygen_dkg_begin()` clears private data in order to reduce the risk of leaks.

This PR replaces `secp256k1_scalar_set_int()` with `secp256k1_scalar_clear()`. The effect is almost identical, but we use a centralized function, with a clear intent, and no additional free parameters.

Note for validating the change: the current implementation is in `src/scalar_low_impl.h` and is the following:

```
SECP256K1_INLINE static void secp256k1_scalar_clear(secp256k1_scalar *r) { *r = 0; }
```

In that same file, immediately below, there is the implementation of `secp256k1_scalar_set_int()`:

```
SECP256K1_INLINE static void secp256k1_scalar_set_int(secp256k1_scalar *r, unsigned int v) { *r = v; }
```

The performance-optimized overloads are in `src/scalar_4x64_impl.h` and `src/scalar_8x32_impl.h`. Their effect is the same, except for operating on 32 or 64 bits chunks.

For an analogous usage of `secp256k1_scalar_clear()`, see for example `secp256k1_schnorrsig_sign_internal()` in `src/modules/schnorrsig/main_impl.h`.
