### PR TITLE
support windows builds

### DIFF
--- a/.github/workflows/tests-for-windows.yml
+++ b/.github/workflows/tests-for-windows.yml
@@ -56,22 +56,18 @@ jobs:
               --enable-module-frost \
               --with-valgrind=no
       - name: "Autotools: build via MinGW"
-        continue-on-error: true
         id: autotools_build
         # we do not need to invoke mingw64-make, because we have already
         # configured the project via mingw64-configure.
         # See: https://fedoraproject.org/wiki/MinGW/Tutorial
         run: make -j
       - name: "Autotools: run frost example via Wine"
-        continue-on-error: true
         id: autotools_frost_example
         run: wine64 ./frost_example.exe
       - name: "Autotools: run functional tests manually via Wine"
-        continue-on-error: true
         id: autotools_functional_tests
         run: wine64 ./tests.exe
       - name: "CMake: build via MinGW"
-        continue-on-error: true
         id: cmake_build
         run: |
           mkdir build
@@ -88,7 +84,6 @@ jobs:
               ..
           make -j
       - name: "CMake: run FROST example via Wine"
-        continue-on-error: true
         id: cmake_frost_example
         run: |
           # frost_example.exe is dynamically linked. Let's copy it under src so
@@ -103,34 +98,6 @@ jobs:
           yes n | cp --interactive "${GITHUB_WORKSPACE}/build/examples/frost_example.exe" "${GITHUB_WORKSPACE}/build/src"
           wine "${GITHUB_WORKSPACE}/build/src/frost_example.exe"
       - name: "Cmake: run functional tests via Wine"
-        continue-on-error: true
         id: cmake_functional_tests
         run: |
           wine "${GITHUB_WORKSPACE}/build/src/tests.exe"
-      - name: "Show that windows build fail with both autotools and CMake"
-        run: |
-          # summary
-          RED='\033[0;31m'
-          GREEN='\033[0;32m'
-          NC='\033[0m' # No Color
-
-          FAIL_THE_STEP=0
-
-          verify_failure() {
-            echo -n "step ${1}: "
-            if [[ "${2}" == "success" ]]; then
-                printf "${RED}ERROR${NC}: the step succeeded: it should have failed!\n"
-                FAIL_THE_STEP=1
-            else
-                printf "${GREEN}OK${NC}: the step failed as expected\n"
-            fi
-          }
-
-          verify_failure autotools_build            ${{ steps.autotools_build.outcome }}
-          verify_failure autotools_frost_example    ${{ steps.autotools_frost_example.outcome }}
-          verify_failure autotools_functional_tests ${{ steps.autotools_functional_tests.outcome }}
-          verify_failure cmake_build                ${{ steps.cmake_build.outcome }}
-          verify_failure cmake_frost_example        ${{ steps.cmake_frost_example.outcome }}
-          verify_failure cmake_functional_tests     ${{ steps.cmake_functional_tests.outcome }}
-
-          exit "${FAIL_THE_STEP}"

--- a/Makefile.am
+++ b/Makefile.am
@@ -97,6 +97,13 @@ libsecp256k1_la_SOURCES = src/secp256k1.c
 libsecp256k1_la_CPPFLAGS = $(SECP_CONFIG_DEFINES)
 libsecp256k1_la_LIBADD = $(COMMON_LIB) $(PRECOMPUTED_LIB)
 libsecp256k1_la_LDFLAGS = -no-undefined -version-info $(LIB_VERSION_CURRENT):$(LIB_VERSION_REVISION):$(LIB_VERSION_AGE)
+# FROST_SPECIFIC - START
+if ENABLE_MODULE_FROST
+if BUILD_WINDOWS
+libsecp256k1_la_LDFLAGS += -lbcrypt
+endif
+endif
+# FROST_SPECIFIC - END
 
 noinst_PROGRAMS =
 if USE_BENCHMARK
@@ -107,9 +114,23 @@ bench_CPPFLAGS = $(SECP_CONFIG_DEFINES)
 bench_internal_SOURCES = src/bench_internal.c
 bench_internal_LDADD = $(COMMON_LIB) $(PRECOMPUTED_LIB)
 bench_internal_CPPFLAGS = $(SECP_CONFIG_DEFINES)
+# FROST_SPECIFIC - START
+if ENABLE_MODULE_FROST
+if BUILD_WINDOWS
+bench_internal_LDFLAGS = -lbcrypt
+endif
+endif
+# FROST_SPECIFIC - END
 bench_ecmult_SOURCES = src/bench_ecmult.c
 bench_ecmult_LDADD = $(COMMON_LIB) $(PRECOMPUTED_LIB)
 bench_ecmult_CPPFLAGS = $(SECP_CONFIG_DEFINES)
+# FROST_SPECIFIC - START
+if ENABLE_MODULE_FROST
+if BUILD_WINDOWS
+bench_ecmult_LDFLAGS = -lbcrypt
+endif
+endif
+# FROST_SPECIFIC - END
 endif
 
 TESTS =
@@ -120,6 +141,13 @@ noverify_tests_SOURCES = src/tests.c
 noverify_tests_CPPFLAGS = $(SECP_CONFIG_DEFINES)
 noverify_tests_LDADD = $(COMMON_LIB) $(PRECOMPUTED_LIB)
 noverify_tests_LDFLAGS = -static
+# FROST_SPECIFIC - START
+if ENABLE_MODULE_FROST
+if BUILD_WINDOWS
+noverify_tests_LDFLAGS += -lbcrypt
+endif
+endif
+# FROST_SPECIFIC - END
 if !ENABLE_COVERAGE
 TESTS += tests
 noinst_PROGRAMS += tests
@@ -127,6 +155,13 @@ tests_SOURCES  = $(noverify_tests_SOURCES)
 tests_CPPFLAGS = $(noverify_tests_CPPFLAGS) -DVERIFY
 tests_LDADD    = $(noverify_tests_LDADD)
 tests_LDFLAGS  = $(noverify_tests_LDFLAGS)
+# FROST_SPECIFIC - START
+if ENABLE_MODULE_FROST
+if BUILD_WINDOWS
+tests_LDFLAGS += -lbcrypt
+endif
+endif
+# FROST_SPECIFIC - END
 endif
 endif
 
@@ -147,6 +182,13 @@ endif
 # Note: do not include $(PRECOMPUTED_LIB) in exhaustive_tests (it uses runtime-generated tables).
 exhaustive_tests_LDADD = $(COMMON_LIB)
 exhaustive_tests_LDFLAGS = -static
+# FROST_SPECIFIC - START
+if ENABLE_MODULE_FROST
+if BUILD_WINDOWS
+exhaustive_tests_LDFLAGS += -lbcrypt
+endif
+endif
+# FROST_SPECIFIC - END
 TESTS += exhaustive_tests
 endif
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,13 @@ add_library(secp256k1_precomputed OBJECT EXCLUDE_FROM_ALL
   precomputed_ecmult_gen.c
 )
 
+# FROST_SPECIFIC - START
+# conditionally add brcypt for Frost-enabled builds on Windows (MinGW)
+target_link_libraries(secp256k1_precomputed PRIVATE
+  $<$<AND:$<BOOL:${SECP256K1_ENABLE_MODULE_FROST}>,$<PLATFORM_ID:Windows>>:bcrypt>
+)
+# FROST_SPECIFIC - END
+
 # Add objects explicitly rather than linking to the object libs to keep them
 # from being exported.
 add_library(secp256k1 secp256k1.c $<TARGET_OBJECTS:secp256k1_precomputed>)
@@ -36,6 +43,13 @@ target_include_directories(secp256k1 INTERFACE
   $<BUILD_INTERFACE:$<$<NOT:$<BOOL:${PROJECT_IS_TOP_LEVEL}>>:${PROJECT_SOURCE_DIR}/include>>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
+
+# FROST_SPECIFIC - START
+# conditionally add brcypt for Frost-enabled builds on Windows (MinGW)
+target_link_libraries(secp256k1 PRIVATE
+  $<$<AND:$<BOOL:${SECP256K1_ENABLE_MODULE_FROST}>,$<PLATFORM_ID:Windows>>:bcrypt>
+)
+# FROST_SPECIFIC - END
 
 # This emulates Libtool to make sure Libtool and CMake agree on the ABI version,
 # see below "Calculate the version variables" in build-aux/ltmain.sh.
@@ -79,19 +93,19 @@ if(SECP256K1_BUILD_BENCHMARK)
   add_executable(bench bench.c)
   target_link_libraries(bench secp256k1)
   add_executable(bench_internal bench_internal.c)
-  target_link_libraries(bench_internal secp256k1_precomputed secp256k1_asm)
+  target_link_libraries(bench_internal secp256k1_precomputed secp256k1_asm $<$<AND:$<BOOL:${SECP256K1_ENABLE_MODULE_FROST}>,$<PLATFORM_ID:Windows>>:bcrypt>) # FROST_SPECIFIC: conditionally add brcypt for Frost-enabled builds on Windows (MinGW)
   add_executable(bench_ecmult bench_ecmult.c)
-  target_link_libraries(bench_ecmult secp256k1_precomputed secp256k1_asm)
+  target_link_libraries(bench_ecmult secp256k1_precomputed secp256k1_asm $<$<AND:$<BOOL:${SECP256K1_ENABLE_MODULE_FROST}>,$<PLATFORM_ID:Windows>>:bcrypt>) # FROST_SPECIFIC: conditionally add brcypt for Frost-enabled builds on Windows (MinGW)
 endif()
 
 if(SECP256K1_BUILD_TESTS)
   add_executable(noverify_tests tests.c)
-  target_link_libraries(noverify_tests secp256k1_precomputed secp256k1_asm)
+  target_link_libraries(noverify_tests secp256k1_precomputed secp256k1_asm $<$<AND:$<BOOL:${SECP256K1_ENABLE_MODULE_FROST}>,$<PLATFORM_ID:Windows>>:bcrypt>) # FROST_SPECIFIC: conditionally add brcypt for Frost-enabled builds on Windows (MinGW)
   add_test(NAME noverify_tests COMMAND noverify_tests)
   if(NOT CMAKE_BUILD_TYPE STREQUAL "Coverage")
     add_executable(tests tests.c)
     target_compile_definitions(tests PRIVATE VERIFY)
-    target_link_libraries(tests secp256k1_precomputed secp256k1_asm)
+    target_link_libraries(tests secp256k1_precomputed secp256k1_asm $<$<AND:$<BOOL:${SECP256K1_ENABLE_MODULE_FROST}>,$<PLATFORM_ID:Windows>>:bcrypt>) # FROST_SPECIFIC: conditionally add brcypt for Frost-enabled builds on Windows (MinGW)
     add_test(NAME tests COMMAND tests)
   endif()
 endif()
@@ -99,7 +113,7 @@ endif()
 if(SECP256K1_BUILD_EXHAUSTIVE_TESTS)
   # Note: do not include secp256k1_precomputed in exhaustive_tests (it uses runtime-generated tables).
   add_executable(exhaustive_tests tests_exhaustive.c)
-  target_link_libraries(exhaustive_tests secp256k1_asm)
+  target_link_libraries(exhaustive_tests secp256k1_asm $<$<AND:$<BOOL:${SECP256K1_ENABLE_MODULE_FROST}>,$<PLATFORM_ID:Windows>>:bcrypt>) # FROST_SPECIFIC: conditionally add brcypt for Frost-enabled builds on Windows (MinGW)
   target_compile_definitions(exhaustive_tests PRIVATE $<$<NOT:$<CONFIG:Coverage>>:VERIFY>)
   add_test(NAME exhaustive_tests COMMAND exhaustive_tests)
 endif()

--- a/src/modules/frost/fill_random.h
+++ b/src/modules/frost/fill_random.h
@@ -1,0 +1,75 @@
+/*************************************************************************
+ * Copyright (c) 2020-2021 Elichai Turkel                                *
+ * Distributed under the CC0 software license, see the accompanying file *
+ * EXAMPLES_COPYING or https://creativecommons.org/publicdomain/zero/1.0 *
+ *************************************************************************/
+
+/*
+ * FROST_SPECIFIC: this file is an excerpt from "examples/examples_util.h" in
+ * the secp256k1 repository.
+ */
+
+/*
+ * This file is an attempt at collecting best practice methods for obtaining randomness with different operating systems.
+ * It may be out-of-date. Consult the documentation of the operating system before considering to use the methods below.
+ *
+ * Platform randomness sources:
+ * Linux   -> `getrandom(2)`(`sys/random.h`), if not available `/dev/urandom` should be used. http://man7.org/linux/man-pages/man2/getrandom.2.html, https://linux.die.net/man/4/urandom
+ * macOS   -> `getentropy(2)`(`sys/random.h`), if not available `/dev/urandom` should be used. https://www.unix.com/man-page/mojave/2/getentropy, https://opensource.apple.com/source/xnu/xnu-517.12.7/bsd/man/man4/random.4.auto.html
+ * FreeBSD -> `getrandom(2)`(`sys/random.h`), if not available `kern.arandom` should be used. https://www.freebsd.org/cgi/man.cgi?query=getrandom, https://www.freebsd.org/cgi/man.cgi?query=random&sektion=4
+ * OpenBSD -> `getentropy(2)`(`unistd.h`), if not available `/dev/urandom` should be used. https://man.openbsd.org/getentropy, https://man.openbsd.org/urandom
+ * Windows -> `BCryptGenRandom`(`bcrypt.h`). https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptgenrandom
+ */
+
+#if defined(_WIN32)
+/*
+ * The defined WIN32_NO_STATUS macro disables return code definitions in
+ * windows.h, which avoids "macro redefinition" MSVC warnings in ntstatus.h.
+ */
+#define WIN32_NO_STATUS
+#include <windows.h>
+#undef WIN32_NO_STATUS
+#include <ntstatus.h>
+#include <bcrypt.h>
+#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
+#include <sys/random.h>
+#elif defined(__OpenBSD__)
+#include <unistd.h>
+#else
+#error "Couldn't identify the OS"
+#endif
+
+#include <stddef.h>
+#include <limits.h>
+#include <stdio.h>
+
+
+/* Returns 1 on success, and 0 on failure. */
+static int fill_random(unsigned char* data, size_t size) {
+#if defined(_WIN32)
+    NTSTATUS res = BCryptGenRandom(NULL, data, size, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+    if (res != STATUS_SUCCESS || size > ULONG_MAX) {
+        return 0;
+    } else {
+        return 1;
+    }
+#elif defined(__linux__) || defined(__FreeBSD__)
+    /* If `getrandom(2)` is not available you should fallback to /dev/urandom */
+    ssize_t res = getrandom(data, size, 0);
+    if (res < 0 || (size_t)res != size ) {
+        return 0;
+    } else {
+        return 1;
+    }
+#elif defined(__APPLE__) || defined(__OpenBSD__)
+    /* If `getentropy(2)` is not available you should fallback to either
+     * `SecRandomCopyBytes` or /dev/urandom */
+    int res = getentropy(data, size);
+    if (res == 0) {
+        return 1;
+    } else {
+        return 0;
+    }
+#endif
+    return 0;
+}

--- a/src/modules/frost/main_impl.h
+++ b/src/modules/frost/main_impl.h
@@ -7,7 +7,7 @@
 #ifndef SECP256K1_MODULE_FROST_MAIN_H
 #define SECP256K1_MODULE_FROST_MAIN_H
 
-#include <sys/random.h>
+#include "fill_random.h"
 #include "../../../include/secp256k1.h"
 #include "../../../include/secp256k1_frost.h"
 
@@ -143,13 +143,14 @@ static SECP256K1_WARN_UNUSED_RESULT int deserialize_frost_signature(secp256k1_fr
 
 static SECP256K1_WARN_UNUSED_RESULT int initialize_random_scalar(secp256k1_scalar *nonce) {
     /*
-     * simplified from:
-     * https://github.com/bitcoin/bitcoin/blob/747cdf1d652d8587e9f2e3d4436c3ecdbf56d0a5/src/secp256k1/examples/random.h
-     * TODO: If `getrandom(2)` is not available you should fall back to /dev/urandom */
+     * WARNING: please be aware that the security of the signature scheme
+     * strongly depends on the quality of the randomness produced by
+     * fill_random(), and fill_random() has not been vetted enough.
+     */
     unsigned char seed[SCALAR_SIZE];
-    ssize_t random_bytes;
-    random_bytes = getrandom(seed, SCALAR_SIZE, 0);
-    if (random_bytes != SCALAR_SIZE) {
+    ssize_t res;
+    res = fill_random(seed, SCALAR_SIZE);
+    if (res != 1) {
         return 0;
     }
     /* Overflow ignored on purpose */


### PR DESCRIPTION
This PR introduces support for windows builds, changing the design of `initialize_random_scalar()` and updating the build scripts.

1. ~~the first commit introduces a `tests-for-windows` CI workflow that builds a win64 version of the library via mingw and runs the resulting windows executables (`frost_example.exe` and `tests.exe`) via Wine.
   In this first iteration, the build fails because frost uses `getrandom()`, which does not exist under windows.
   The workflow enforces this failure;~~
2. the second commit replaces `getrandom()` with `BCryptGenRandom()` under windows, drawing from upstream's `examples/examples_util.h` which shows a cross-platform way of filling buffers with randomness.
   The build is now cross-platform, and the workflow `tests-for-windows` workflow is flipped to enforce success.

**edit**: split this PR in two. #38 can be merged before this one. While this PR groups the design changes necessary to support building Frost for Windows.