### PR TITLE
frost: show that header precompilation would fail

### DIFF
--- a/.github/workflows/check-frost-header.yml
+++ b/.github/workflows/check-frost-header.yml
@@ -1,0 +1,59 @@
+name: Check that frost header fails to be precompiled
+
+on:
+  push:
+    branches:
+      - frost
+  pull_request:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  precompile_frost_header:
+    runs-on: ubuntu-24.04
+    # Use fedora:41 to compile using gcc-14.2
+    container:
+      image: fedora:41
+    steps:
+      - name: Install build dependencies
+        run: |
+          dnf install -y \
+              g++ \
+              gcc
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Check that frost header fails to be precompiled (C)
+        continue-on-error: true
+        id: precompile_frost_header_c
+        run: |
+          scripts/ensure-frost-header-is-precompilable.sh c
+      - name: Check that frost header fails to be precompiled (C++)
+        continue-on-error: true
+        id: precompile_frost_header_cpp
+        run: |
+          scripts/ensure-frost-header-is-precompilable.sh c++
+      - name: Summarize outcomes. Fail if any step failed.
+        run: |
+          # summary
+          RED='\033[0;31m'
+          GREEN='\033[0;32m'
+          NC='\033[0m' # No Color
+
+          echo -n "Check that frost header can be precompiled (C): "
+          if [[ ${{ steps.precompile_frost_header_c.outcome }} == "success" ]]; then
+            printf "${RED}FAIL${NC} the step suceeded (${{ steps.precompile_frost_header_c.outcome }}), but it should have failed. Please check\n"
+          else
+            printf "${GREEN}SUCCESS${NC}: the step failed as expected\n"
+          fi
+
+          echo -n "Check that frost header can be precompiled (C++): "
+          if [[ ${{ steps.precompile_frost_header_cpp.outcome }} == "success" ]]; then
+            printf "${RED}FAIL${NC} the step suceeded (${{ steps.precompile_frost_header_cpp.outcome }}), but it should have failed. Please check\n"
+          else
+            printf "${GREEN}SUCCESS${NC}: the step failed as expected\n"
+          fi
+
+          if [[ ${{ steps.precompile_frost_header_c.outcome }} == "success" ]] || [[ ${{ steps.precompile_frost_header_cpp.outcome }} == "success" ]]; then
+            exit 1
+          fi

--- a/scripts/ensure-frost-header-is-precompilable.sh
+++ b/scripts/ensure-frost-header-is-precompilable.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Checks that frost header secp256k1_frost.h can be precompiled.
+#
+# What we would really like to do is trying to compile every header in the code
+# base with this command:
+#     gcc -Werror -pedantic-errors include/*.h
+#     g++ -Werror -pedantic-errors include/*.h
+#
+# but that command would litter the working directory. We cannot directly use
+# -o /dev/null because gcc does not support it for precompiled headers (see:
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108732#c2), so we have to use
+# this incantation.
+
+set -u
+set -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+errecho() {
+    # prints to stderr
+    >&2 echo "${@}"
+}
+
+log_info() {
+    errecho "INFO: ${1}"
+}
+
+log_warning() {
+    errecho "WARNING: ${1}"
+}
+
+log_error() {
+    errecho "ERROR: ${1}"
+}
+
+checkPrerequisites() {
+    if ! command -v gcc &> /dev/null
+    then
+        log_error "Please install gcc"
+        exit 1
+    fi
+    if ! command -v g++ &> /dev/null
+    then
+        log_error "Please install g++"
+        exit 1
+    fi
+}
+
+checkPrerequisites
+
+if [ "$#" -ne 1 ]; then
+    log_error "You must enter exactly 1 command line argument ('c' or 'c++')"
+    exit 1
+fi
+
+if [ "$1" != "c" ] && [ "$1" != "c++" ]; then
+    log_error "USAGE: $0 <c|c++>"
+    exit 1
+fi
+
+LANGUAGE="$1"
+
+FROST_HEADER_PATH=$(realpath "${SCRIPT_DIR}/../include/secp256k1_frost.h")
+log_info "Tryng to compile ${FROST_HEADER_PATH} with ${LANGUAGE}"
+
+gcc -x"${LANGUAGE}" -c -Werror -pedantic-errors -include "${FROST_HEADER_PATH}" /dev/null -o /dev/null
+
+log_info "OK (${LANGUAGE})"


### PR DESCRIPTION
This PR introduces a simple script that triggers the current failure to precompile the frost header, due to a missing `uint32_t` symbol, and introduces a CI workflow that verifies the failure (in order to fix it afterwards).

The script uses a convoluted syntax (taken from https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108732#c2) to trigger the header precompilation without actually writing anything to disk. The reason is that for header precompilation gcc 14.2 (2025-04-07), does not support `-o /dev/null`, because it wants to mmap the output file.

In order to be as strict as possible, we compile in both C and C++, because the headers for fixed length integers have different names in the two languages.

**EVIDENCE OF THE ERROR (C)**:
```
$ scripts/ensure-frost-header-is-precompilable.sh c
INFO: Tryng to compile <BASE>/include/secp256k1_frost.h with c
In file included from <command-line>:
<BASE>/include/secp256k1_frost.h:19:5: error: unknown type name ‘uint32_t’
   19 |     uint32_t generator_index;
      |     ^~~~~~~~
<BASE>/include/secp256k1_frost.h:12:1: note: ‘uint32_t’ is defined in header ‘<stdint.h>’; this is probably fixable by adding ‘#include <stdint.h>’
   11 | #include "secp256k1_extrakeys.h"
  +++ |+#include <stdint.h>
   12 |
```

**EVIDENCE OF THE ERROR (C++)**:
```
$ scripts/ensure-frost-header-is-precompilable.sh c++
INFO: Tryng to compile <BASE>/include/secp256k1_frost.h with c++
In file included from <command-line>:
<BASE>/include/secp256k1_frost.h:19:5: error: ‘uint32_t’ does not name a type
   19 |     uint32_t generator_index;
      |     ^~~~~~~~
<BASE>/include/secp256k1_frost.h:12:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   11 | #include "secp256k1_extrakeys.h"
  +++ |+#include <cstdint>
   12 |
```