### PR TITLE
frost: fix header precompilation error

### DIFF
--- a/.github/workflows/check-frost-header.yml
+++ b/.github/workflows/check-frost-header.yml
@@ -1,4 +1,4 @@
-name: Check that frost header fails to be precompiled
+name: Check that frost header can be precompiled
 
 on:
   push:
@@ -23,12 +23,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Check that frost header fails to be precompiled (C)
+      - name: Check that frost header can be precompiled (C)
         continue-on-error: true
         id: precompile_frost_header_c
         run: |
           scripts/ensure-frost-header-is-precompilable.sh c
-      - name: Check that frost header fails to be precompiled (C++)
+      - name: Check that frost header can be precompiled (C++)
         continue-on-error: true
         id: precompile_frost_header_cpp
         run: |
@@ -42,18 +42,18 @@ jobs:
 
           echo -n "Check that frost header can be precompiled (C): "
           if [[ ${{ steps.precompile_frost_header_c.outcome }} == "success" ]]; then
-            printf "${RED}FAIL${NC} the step suceeded (${{ steps.precompile_frost_header_c.outcome }}), but it should have failed. Please check\n"
+            printf "${GREEN}SUCCESS${NC}\n"
           else
-            printf "${GREEN}SUCCESS${NC}: the step failed as expected\n"
+            printf "${RED}FAIL${NC} (${{ steps.precompile_frost_header_c.outcome }}), please check\n"
           fi
 
           echo -n "Check that frost header can be precompiled (C++): "
           if [[ ${{ steps.precompile_frost_header_cpp.outcome }} == "success" ]]; then
-            printf "${RED}FAIL${NC} the step suceeded (${{ steps.precompile_frost_header_cpp.outcome }}), but it should have failed. Please check\n"
+            printf "${GREEN}SUCCESS${NC}\n"
           else
-            printf "${GREEN}SUCCESS${NC}: the step failed as expected\n"
+            printf "${RED}FAIL${NC} (${{ steps.precompile_frost_header_cpp.outcome }}), please check\n"
           fi
 
-          if [[ ${{ steps.precompile_frost_header_c.outcome }} == "success" ]] || [[ ${{ steps.precompile_frost_header_cpp.outcome }} == "success" ]]; then
+          if [[ ${{ steps.precompile_frost_header_c.outcome }} != "success" ]] || [[ ${{ steps.precompile_frost_header_cpp.outcome }} != "success" ]]; then
             exit 1
           fi

--- a/include/secp256k1_frost.h
+++ b/include/secp256k1_frost.h
@@ -7,6 +7,23 @@
 #ifndef SECP256K1_FROST_H
 #define SECP256K1_FROST_H
 
+/*
+ * The following inclusions are needed to bring uint32_t in scope in a platform
+ * and language independent way.
+ * Without this snippet the following commands would fail:
+ *     gcc -xc++ -c -Werror -pedantic-errors -include include/secp256k1_frost.h /dev/null -o /dev/null
+ *     gcc -xc   -c -Werror -pedantic-errors -include include/secp256k1_frost.h /dev/null -o /dev/null
+ *
+ * references:
+ *     scripts/ensure-frost-header-is-precompilable.sh
+ *     https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108732#c2 (for the gcc invocation syntax)
+ */
+#ifdef __cplusplus
+    #include <cstdint>
+#else
+    #include <stdint.h>
+#endif
+
 #include "secp256k1.h"
 #include "secp256k1_extrakeys.h"
 


### PR DESCRIPTION
#39 showed that the frost module's header could not be precompiled.

This PR fixes the error and updates the CI in order to ensure it never happens again.

Depending on the host language, we include the proper stdlib header for fixed size integers: `<stdint.h>` for C and `<cstdint>` for C++.
