### PR TITLE
Release v0.3.2-frost-2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ project(libsecp256k1
   # The package (a.k.a. release) version is based on semantic versioning 2.0.0 of
   # the API. All changes in experimental modules are treated as
   # backwards-compatible and therefore at most increase the minor version.
-  VERSION 0.3.2.1 # FROST_SPECIFIC: the fourth number must be equal to the value of _PKG_VERSION_FROST_BUILD in configure.ac
+  VERSION 0.3.2.2 # FROST_SPECIFIC: the fourth number must be equal to the value of _PKG_VERSION_FROST_BUILD in configure.ac
   DESCRIPTION "Optimized C library for ECDSA signatures and secret/public key operations on curve secp256k1."
   HOMEPAGE_URL "https://github.com/bancaditalia/secp256k1-frost" # FROST_SPECIFIC: replaced URIs with those of Bank of Italy's fork.
   LANGUAGES C

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_PREREQ([2.60])
 define(_PKG_VERSION_MAJOR, 0)
 define(_PKG_VERSION_MINOR, 3)
 define(_PKG_VERSION_PATCH, 2)
-define(_PKG_VERSION_FROST_BUILD, 1) # FROST_SPECIFIC: this field controls the final digit in the version identifier "MAJOR.MINOR.BUILD-frost-FROST_BUILD". WARNING: this number should be equal to the fourth digit of project(... VERSION ...) in CMakeLists.txt
+define(_PKG_VERSION_FROST_BUILD, 2) # FROST_SPECIFIC: this field controls the final digit in the version identifier "MAJOR.MINOR.BUILD-frost-FROST_BUILD". WARNING: this number should be equal to the fourth digit of project(... VERSION ...) in CMakeLists.txt
 define(_PKG_VERSION_IS_RELEASE, true)
 
 # The library version is based on libtool versioning of the ABI. The set of
@@ -128,7 +128,7 @@ AC_DEFUN([SECP_TRY_APPEND_DEFAULT_CFLAGS], [
       # (See the libtool manual, section "Windows DLLs" for background.)
       # Unfortunately, libtool tries to be too clever and strips "-Xlinker arg"
       # into "arg", so this will be " -Xlinker -ignore:4217" after stripping.
-      LDFLAGS="-Xlinker -Xlinker -Xlinker -ignore:4217 $LDFLAGS" 
+      LDFLAGS="-Xlinker -Xlinker -Xlinker -ignore:4217 $LDFLAGS"
     fi
 ])
 SECP_TRY_APPEND_DEFAULT_CFLAGS(SECP_CFLAGS)


### PR DESCRIPTION
The version that need to go into itcoin-v25 is **v0.3.2-frost-1**, and is not based on the final version of secp256k1 (because bitcoin v25 did so).

This proposed version (**v0.3.2-frost-2**), instead, incorporates the final secp256k1 v0.3.2, and includes our recent changes: simplifications in the math performed in the frost module, multiplatform support and better CI checks.

These changes originated from the upgrading effort to v0.4.0 (#35), that we decided to apply to 0.3.2 _before_ upgrading the secp256k1 version.