### PR TITLE
ci: update toolchain to Fedora 42 / GCC 15.1

### DIFF
--- a/.github/workflows/build-with-cmake.yml
+++ b/.github/workflows/build-with-cmake.yml
@@ -11,9 +11,9 @@ on:
 jobs:
   build-with-cmake:
     runs-on: ubuntu-24.04
-    # Use fedora:41 to compile using gcc-14.2
+    # Use fedora:42 to compile using gcc-15.1
     container:
-      image: fedora:41
+      image: fedora:42
     steps:
       - name: Install build dependencies
         run: |

--- a/.github/workflows/check-frost-header.yml
+++ b/.github/workflows/check-frost-header.yml
@@ -11,9 +11,9 @@ on:
 jobs:
   precompile_frost_header:
     runs-on: ubuntu-24.04
-    # Use fedora:41 to compile using gcc-14.2
+    # Use fedora:42 to compile using gcc-15.1
     container:
-      image: fedora:41
+      image: fedora:42
     steps:
       - name: Install build dependencies
         run: |

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -1,4 +1,4 @@
-name: Functional tests, gcc14
+name: Functional tests, gcc15
 
 # In secp256k1 some assertions are not exactly equal when coverage is enabled
 # and when it is not. Hence, it is better to run the two cases separately.
@@ -14,9 +14,9 @@ on:
 jobs:
   functional-tests:
     runs-on: ubuntu-24.04
-    # Use fedora:41 to compile using gcc-14.2
+    # Use fedora:42 to compile using gcc-15.1
     container:
-      image: fedora:41
+      image: fedora:42
     steps:
       - name: Install build dependencies
         run: |
@@ -24,6 +24,7 @@ jobs:
               autoconf \
               automake \
               diffutils \
+              gawk \
               gcc \
               gcovr \
               libtool \

--- a/.github/workflows/tests-and-examples-under-valgrind.yml
+++ b/.github/workflows/tests-and-examples-under-valgrind.yml
@@ -11,15 +11,16 @@ on:
 jobs:
   tests-and-examples-under-valgrind:
     runs-on: ubuntu-24.04
-    # Use fedora:41 to compile using gcc-14.2
+    # Use fedora:42 to compile using gcc-15.1
     container:
-      image: fedora:41
+      image: fedora:42
     steps:
       - name: Install build dependencies and Valgrind
         run: |
           dnf install -y \
               autoconf \
               automake \
+              gawk \
               gcc \
               libtool \
               pkg-config \

--- a/.github/workflows/tests-for-windows.yml
+++ b/.github/workflows/tests-for-windows.yml
@@ -12,7 +12,7 @@ jobs:
   example-and-tests-mingw-autotools-cmake:
     runs-on: ubuntu-24.04
     container:
-      image: fedora:41
+      image: fedora:42
     steps:
       - name: Install build dependencies
         run: |
@@ -21,6 +21,7 @@ jobs:
               autoconf \
               automake \
               cmake \
+              gawk \
               libtool \
               mingw64-gcc \
               pkg-config \
@@ -90,12 +91,10 @@ jobs:
           # that wine's linker is able to find libsecp256k1-2.dll. There is
           # probably a more elegant way.
           #
-          # About the use of "yes n | cp ...": is is an ugly workaround because
-          # coreutils 9.5 (which are part of Fedora 41) do not support
-          # cp --update=none-fail because of a bug.
-          #
-          # TODO: replace with --update=none-fail when possible
-          yes n | cp --interactive "${GITHUB_WORKSPACE}/build/examples/frost_example.exe" "${GITHUB_WORKSPACE}/build/src"
+          # "--update=none-fail" did not work on coreutils 9.5 (Fedora 41) due
+          # to a bug. It required a workaround that is no longer necessary with
+          # coreutils 9.6 (Fedora 42).
+          cp --update=none-fail "${GITHUB_WORKSPACE}/build/examples/frost_example.exe" "${GITHUB_WORKSPACE}/build/src"
           wine "${GITHUB_WORKSPACE}/build/src/frost_example.exe"
       - name: "Cmake: run functional tests via Wine"
         id: cmake_functional_tests

--- a/examples/frost.c
+++ b/examples/frost.c
@@ -18,9 +18,9 @@
 #define EXAMPLE_MIN_PARTICIPANTS 2
 
 int main(void) {
-    unsigned char msg[12] = "Hello World!";
+    unsigned char msg[12] = {'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd', '!'};
     unsigned char msg_hash[32];
-    unsigned char tag[14] = "frost_protocol";
+    unsigned char tag[14] = {'f', 'r', 'o', 's', 't', '_', 'p', 'r', 'o', 't', 'o', 'c', 'o', 'l'};
     uint32_t index;
     unsigned char binding_seed[32] = {0};
     unsigned char hiding_seed[32] = {0};

--- a/examples/schnorr.c
+++ b/examples/schnorr.c
@@ -18,9 +18,9 @@
 #include "examples_util.h"
 
 int main(void) {
-    unsigned char msg[12] = "Hello World!";
+    unsigned char msg[] = {'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd', '!'};
     unsigned char msg_hash[32];
-    unsigned char tag[17] = "my_fancy_protocol";
+    unsigned char tag[] = {'m', 'y', '_', 'f', 'a', 'n', 'c', 'y', '_', 'p', 'r', 'o', 't', 'o', 'c', 'o', 'l'};
     unsigned char seckey[32];
     unsigned char randomize[32];
     unsigned char auxiliary_rand[32];

--- a/src/modules/ellswift/tests_impl.h
+++ b/src/modules/ellswift/tests_impl.h
@@ -406,9 +406,9 @@ void run_ellswift_tests(void) {
     /* Test hash initializers. */
     {
         secp256k1_sha256 sha, sha_optimized;
-        static const unsigned char encode_tag[25] = "secp256k1_ellswift_encode";
-        static const unsigned char create_tag[25] = "secp256k1_ellswift_create";
-        static const unsigned char bip324_tag[26] = "bip324_ellswift_xonly_ecdh";
+        static const unsigned char encode_tag[] = {'s', 'e', 'c', 'p', '2', '5', '6', 'k', '1', '_', 'e', 'l', 'l', 's', 'w', 'i', 'f', 't', '_', 'e', 'n', 'c', 'o', 'd', 'e'};
+        static const unsigned char create_tag[] = {'s', 'e', 'c', 'p', '2', '5', '6', 'k', '1', '_', 'e', 'l', 'l', 's', 'w', 'i', 'f', 't', '_', 'c', 'r', 'e', 'a', 't', 'e'};
+        static const unsigned char bip324_tag[] = {'b', 'i', 'p', '3', '2', '4', '_', 'e', 'l', 'l', 's', 'w', 'i', 'f', 't', '_', 'x', 'o', 'n', 'l', 'y', '_', 'e', 'c', 'd', 'h'};
 
         /* Check that hash initialized by
          * secp256k1_ellswift_sha256_init_encode has the expected

--- a/src/modules/frost/main_impl.h
+++ b/src/modules/frost/main_impl.h
@@ -11,10 +11,10 @@
 #include "../../../include/secp256k1.h"
 #include "../../../include/secp256k1_frost.h"
 
-static const unsigned char hash_context_prefix_h1[29] = "FROST-secp256k1-SHA256-v11rho";
-static const unsigned char hash_context_prefix_h3[31] = "FROST-secp256k1-SHA256-v11nonce";
-static const unsigned char hash_context_prefix_h4[29] = "FROST-secp256k1-SHA256-v11msg";
-static const unsigned char hash_context_prefix_h5[29] = "FROST-secp256k1-SHA256-v11com";
+static const unsigned char hash_context_prefix_h1[29] = {'F', 'R', 'O', 'S', 'T', '-', 's', 'e', 'c', 'p', '2', '5', '6', 'k', '1', '-', 'S', 'H', 'A', '2', '5', '6', '-', 'v', '1', '1', 'r', 'h', 'o'};
+static const unsigned char hash_context_prefix_h3[31] = {'F', 'R', 'O', 'S', 'T', '-', 's', 'e', 'c', 'p', '2', '5', '6', 'k', '1', '-', 'S', 'H', 'A', '2', '5', '6', '-', 'v', '1', '1', 'n', 'o', 'n', 'c', 'e'};
+static const unsigned char hash_context_prefix_h4[29] = {'F', 'R', 'O', 'S', 'T', '-', 's', 'e', 'c', 'p', '2', '5', '6', 'k', '1', '-', 'S', 'H', 'A', '2', '5', '6', '-', 'v', '1', '1', 'm', 's', 'g'};
+static const unsigned char hash_context_prefix_h5[29] = {'F', 'R', 'O', 'S', 'T', '-', 's', 'e', 'c', 'p', '2', '5', '6', 'k', '1', '-', 'S', 'H', 'A', '2', '5', '6', '-', 'v', '1', '1', 'c', 'o', 'm'};
 
 #define SCALAR_SIZE (32U)
 #define SHA256_SIZE (32U)
@@ -173,7 +173,7 @@ static void compute_hash_h2(const unsigned char *msg, uint32_t msg_len, unsigned
     /* TODO: replace with hash-to-curve
     * H2(m): Implemented using hash_to_field from [HASH-TO-CURVE], Section 5.2 using L = 48,
     * expand_message_xmd with SHA-256, DST = "FROST-secp256k1-SHA256-v11" || "chal", and prime modulus equal to Order().*/
-    const unsigned char prefix[17] = "BIP0340/challenge";
+    const unsigned char prefix[17] = {'B', 'I', 'P', '0', '3', '4', '0', '/', 'c', 'h', 'a', 'l', 'l', 'e', 'n', 'g', 'e'};
     secp256k1_sha256 sha;
     secp256k1_sha256_initialize(&sha);
     secp256k1_sha256_write(&sha, prefix, sizeof(prefix));

--- a/src/modules/frost/tests_impl.h
+++ b/src/modules/frost/tests_impl.h
@@ -81,7 +81,7 @@ void test_secp256k1_gej_eq_case_4(void) {
 void test_nonce_generate_with_seed(void) {
     unsigned char buffer[32] = {0};
     unsigned char check[32] = {0};
-    unsigned char seed[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    unsigned char seed[33] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     uint32_t index;
     int init;
     secp256k1_frost_keypair keypair;
@@ -294,7 +294,7 @@ void test_secp256k1_frost_keypair_destroy_null_keypair(void) {
  */
 void test_secp256k1_frost_keygen_begin_invalid_participants(void) {
     int result;
-    const unsigned char context[4] = "test";
+    const unsigned char context[4] = {'t', 'e', 's', 't'};
     secp256k1_context *sign_ctx;
     secp256k1_frost_vss_commitments *dkg_commitment;
     secp256k1_frost_keygen_secret_share shares[3];
@@ -316,7 +316,7 @@ void test_secp256k1_frost_keygen_begin_invalid_participants(void) {
  */
 void test_secp256k1_frost_keygen_begin_invalid_threshold(void) {
     int result;
-    const unsigned char context[4] = "test";
+    const unsigned char context[4] = {'t', 'e', 's', 't'};
     secp256k1_context *sign_ctx;
     secp256k1_frost_vss_commitments *dkg_commitment;
     secp256k1_frost_keygen_secret_share shares[3];
@@ -338,7 +338,7 @@ void test_secp256k1_frost_keygen_begin_invalid_threshold(void) {
  */
 void test_secp256k1_frost_keygen_begin_threshold_gt_participants(void) {
     int result;
-    const unsigned char context[4] = "test";
+    const unsigned char context[4] = {'t', 'e', 's', 't'};
     secp256k1_context *sign_ctx;
     secp256k1_frost_vss_commitments *dkg_commitment;
     secp256k1_frost_keygen_secret_share shares[3];
@@ -364,7 +364,7 @@ void test_secp256k1_frost_keygen_begin_null_secp_context(void) {
     secp256k1_frost_vss_commitments *dkg_commitment;
     secp256k1_frost_keygen_secret_share shares[3];
     int result;
-    const unsigned char context[4] = "test";
+    const unsigned char context[4] = {'t', 'e', 's', 't'};
 
     dkg_commitment = secp256k1_frost_vss_commitments_create(2);
     result = secp256k1_frost_keygen_dkg_begin(sign_ctx, dkg_commitment, shares,
@@ -384,7 +384,7 @@ void test_secp256k1_frost_keygen_begin_null_commitment(void) {
     secp256k1_frost_vss_commitments *dkg_commitment = NULL;
     secp256k1_frost_keygen_secret_share shares[3];
     int result;
-    const unsigned char context[4] = "test";
+    const unsigned char context[4] = {'t', 'e', 's', 't'};
 
     sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
     result = secp256k1_frost_keygen_dkg_begin(sign_ctx, dkg_commitment, shares,
@@ -403,7 +403,7 @@ void test_secp256k1_frost_keygen_begin_null_shares(void) {
     secp256k1_frost_vss_commitments *dkg_commitment;
     secp256k1_frost_keygen_secret_share *shares = NULL;
     int result;
-    const unsigned char context[4] = "test";
+    const unsigned char context[4] = {'t', 'e', 's', 't'};
 
     sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
     dkg_commitment = secp256k1_frost_vss_commitments_create(2);
@@ -444,7 +444,7 @@ void test_secp256k1_frost_keygen_begin(void) {
     secp256k1_frost_vss_commitments *dkg_commitment;
     secp256k1_frost_keygen_secret_share shares[3];
     int result;
-    const unsigned char context[4] = "test";
+    const unsigned char context[4] = {'t', 'e', 's', 't'};
 
     sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
     dkg_commitment = secp256k1_frost_vss_commitments_create(2);
@@ -465,7 +465,7 @@ void test_secp256k1_frost_keygen_validate(void) {
     secp256k1_frost_vss_commitments *dkg_commitment;
     secp256k1_frost_keygen_secret_share shares[3];
     int result;
-    const unsigned char context[4] = "test";
+    const unsigned char context[4] = {'t', 'e', 's', 't'};
 
     sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
     dkg_commitment = secp256k1_frost_vss_commitments_create(2);
@@ -490,7 +490,7 @@ void test_secp256k1_frost_keygen_validate_null_secp_context(void) {
     secp256k1_frost_vss_commitments *dkg_commitment;
     secp256k1_frost_keygen_secret_share shares[3];
     int result;
-    const unsigned char context[4] = "test";
+    const unsigned char context[4] = {'t', 'e', 's', 't'};
 
     sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
     dkg_commitment = secp256k1_frost_vss_commitments_create(2);
@@ -515,7 +515,7 @@ void test_secp256k1_frost_keygen_validate_null_commitment(void) {
     secp256k1_frost_vss_commitments *dkg_commitment;
     secp256k1_frost_keygen_secret_share shares[3];
     int result;
-    const unsigned char context[4] = "test";
+    const unsigned char context[4] = {'t', 'e', 's', 't'};
 
     sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
     dkg_commitment = secp256k1_frost_vss_commitments_create(2);
@@ -540,7 +540,7 @@ void test_secp256k1_frost_keygen_validate_null_context(void) {
     secp256k1_frost_vss_commitments *dkg_commitment;
     secp256k1_frost_keygen_secret_share shares[3];
     int result;
-    const unsigned char context[4] = "test";
+    const unsigned char context[4] = {'t', 'e', 's', 't'};
 
     sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
     dkg_commitment = secp256k1_frost_vss_commitments_create(2);
@@ -569,7 +569,7 @@ void test_secp256k1_frost_keygen_validate_invalid_secret_commitment(void) {
     secp256k1_frost_keygen_secret_share shares[3];
     secp256k1_gej _invalidPoint;
     int result;
-    const unsigned char context[4] = "test";
+    const unsigned char context[4] = {'t', 'e', 's', 't'};
     const uint32_t threshold = 2;
 
     sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
@@ -603,8 +603,8 @@ void test_secp256k1_frost_keygen_validate_invalid_context(void) {
     secp256k1_frost_vss_commitments *dkg_commitment;
     secp256k1_frost_keygen_secret_share shares[3];
     int result;
-    const unsigned char context[4] = "test";
-    const unsigned char invalid_context[7] = "invalid";
+    const unsigned char context[4] = {'t', 'e', 's', 't'};
+    const unsigned char invalid_context[7] = {'i', 'n', 'v', 'a', 'l', 'i', 'd'};
 
     sign_ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
     dkg_commitment = secp256k1_frost_vss_commitments_create(2);
@@ -638,7 +638,7 @@ void test_secp256k1_frost_keygen_finalize(void) {
     uint32_t num_participants;
     secp256k1_frost_keypair keypair;
     uint32_t index;
-    const unsigned char context[4] = "test";
+    const unsigned char context[4] = {'t', 'e', 's', 't'};
     const uint32_t threshold = 2;
 
     /* Step 1. initialization */
@@ -775,7 +775,7 @@ void test_secp256k1_frost_keygen_finalize_is_valid(void) {
     uint32_t num_participants;
     secp256k1_frost_keypair keypairs[3];
     uint32_t index;
-    const unsigned char context[4] = "test";
+    const unsigned char context[4] = {'t', 'e', 's', 't'};
 
     /* Step 1. initialization */
     num_participants = 3;
@@ -865,7 +865,7 @@ void test_secp256k1_frost_keygen_finalize_different_participant_index(void) {
     uint32_t num_participants;
     secp256k1_frost_keypair keypair;
     uint32_t index;
-    const unsigned char context[4] = "test";
+    const unsigned char context[4] = {'t', 'e', 's', 't'};
 
     /* Step 1. initialization */
     num_participants = 3;
@@ -924,7 +924,7 @@ void test_secp256k1_frost_keygen_finalize_invalid_commitments(void) {
     uint32_t num_participants;
     secp256k1_frost_keypair keypair;
     uint32_t index;
-    const unsigned char context[4] = "test";
+    const unsigned char context[4] = {'t', 'e', 's', 't'};
     secp256k1_gej _invalidPoint;
 
     /* Step 1. initialization */
@@ -1023,8 +1023,8 @@ void test_secp256k1_frost_dkg_and_sign(void) {
     uint32_t num_participants;
     secp256k1_frost_keypair keypair[3];
     uint32_t index;
-    const unsigned char context[4] = "test";
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char context[4] = {'t', 'e', 's', 't'};
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     unsigned char binding_seed[32] = {0};
     unsigned char hiding_seed[32] = {0};
     secp256k1_frost_signature_share signature_share[3];
@@ -1358,7 +1358,7 @@ void test_secp256k1_frost_single_dealer_and_sign(void) {
     secp256k1_frost_keypair keypairs[3];
 
     uint32_t index;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     unsigned char binding_seed[32] = {0};
     unsigned char hiding_seed[32] = {0};
     secp256k1_frost_signature_share signature_share[3];
@@ -1409,7 +1409,7 @@ void test_secp256k1_frost_sign_null_signature_shares(void) {
     secp256k1_frost_keypair keypairs;
     secp256k1_frost_nonce nonces;
     secp256k1_frost_nonce_commitment signing_commitments;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     threshold_signers = 2;
 
     memset(&keypairs, 0, sizeof(secp256k1_frost_keypair));
@@ -1457,7 +1457,7 @@ void test_secp256k1_frost_sign_null_keypairs(void) {
     secp256k1_frost_keypair *keypairs = NULL;
     secp256k1_frost_nonce nonces;
     secp256k1_frost_nonce_commitment signing_commitments;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     threshold_signers = 2;
 
     memset(&signature_share, 0, sizeof(secp256k1_frost_signature_share));
@@ -1480,7 +1480,7 @@ void test_secp256k1_frost_sign_null_nonces(void) {
     secp256k1_frost_keypair keypairs;
     secp256k1_frost_nonce *nonces = NULL;
     secp256k1_frost_nonce_commitment signing_commitments;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     threshold_signers = 2;
 
     memset(&signature_share, 0, sizeof(secp256k1_frost_signature_share));
@@ -1503,7 +1503,7 @@ void test_secp256k1_frost_sign_null_signing_commitments(void) {
     secp256k1_frost_keypair keypairs;
     secp256k1_frost_nonce nonces;
     secp256k1_frost_nonce_commitment *signing_commitments = NULL;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     threshold_signers = 2;
 
     memset(&signature_share, 0, sizeof(secp256k1_frost_signature_share));
@@ -1526,7 +1526,7 @@ void test_secp256k1_frost_sign_num_signer_set_to_zero(void) {
     secp256k1_frost_keypair keypairs;
     secp256k1_frost_nonce nonces;
     secp256k1_frost_nonce_commitment signing_commitments;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     threshold_signers = 0;
 
     memset(&signature_share, 0, sizeof(secp256k1_frost_signature_share));
@@ -1554,7 +1554,7 @@ void test_secp256k1_frost_sign_more_participants_than_max_to_be_invalid(void) {
     secp256k1_frost_pubkey public_keys[3];
 
     uint32_t index;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     unsigned char binding_seed[32] = {0};
     unsigned char hiding_seed[32] = {0};
     secp256k1_frost_signature_share signature_shares[3];
@@ -1620,7 +1620,7 @@ void test_secp256k1_frost_sign_aggregate_verify_to_be_valid(void) {
     secp256k1_frost_pubkey public_keys[3];
 
     uint32_t index;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     unsigned char binding_seed[32] = {0};
     unsigned char hiding_seed[32] = {0};
     secp256k1_frost_signature_share signature_shares[3];
@@ -1704,7 +1704,7 @@ void test_secp256k1_frost_sign_aggregate_verify_more_parts_to_be_valid(void) {
     secp256k1_frost_pubkey public_keys[10];
 
     uint32_t index;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     unsigned char binding_seed[32] = {0};
     unsigned char hiding_seed[32] = {0};
     secp256k1_frost_signature_share signature_shares[10];
@@ -1788,7 +1788,7 @@ void test_secp256k1_frost_sign_with_used_nonce_to_not_sign(void) {
     secp256k1_frost_keypair keypairs[3];
 
     uint32_t index;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     unsigned char binding_seed[32] = {0};
     unsigned char hiding_seed[32] = {0};
     secp256k1_frost_signature_share signature_shares[3];
@@ -1852,7 +1852,7 @@ void test_secp256k1_frost_with_larger_params_to_be_valid(void) {
     secp256k1_frost_pubkey public_keys[10];
 
     uint32_t index;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     unsigned char binding_seed[32] = {0};
     unsigned char hiding_seed[32] = {0};
     secp256k1_frost_signature_share signature_shares[10];
@@ -1936,7 +1936,7 @@ void test_secp256k1_frost_aggregate_with_all_signers_to_be_valid(void) {
     secp256k1_frost_pubkey public_keys[3];
 
     uint32_t index;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     unsigned char binding_seed[32] = {0};
     unsigned char hiding_seed[32] = {0};
     secp256k1_frost_signature_share signature_shares[3];
@@ -2008,7 +2008,7 @@ void test_secp256k1_frost_aggregate_with_all_signers_to_be_valid(void) {
 void test_secp256k1_frost_aggregate_null_secp_context(void) {
     secp256k1_context *sign_ctx = NULL;
     unsigned char signature[64];
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     secp256k1_frost_keypair keypair;
     secp256k1_frost_pubkey public_keys[3];
     secp256k1_frost_signature_share signature_shares[3];
@@ -2034,7 +2034,7 @@ void test_secp256k1_frost_aggregate_null_secp_context(void) {
 void test_secp256k1_frost_aggregate_null_signature(void) {
     secp256k1_context *sign_ctx;
     unsigned char *signature = NULL;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     secp256k1_frost_keypair keypair;
     secp256k1_frost_pubkey public_keys[3];
     secp256k1_frost_signature_share signature_shares[3];
@@ -2096,7 +2096,7 @@ void test_secp256k1_frost_aggregate_null_message(void) {
 void test_secp256k1_frost_aggregate_null_keypair(void) {
     secp256k1_context *sign_ctx;
     unsigned char signature[64];
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     secp256k1_frost_keypair *keypair = NULL;
     secp256k1_frost_pubkey public_keys[3];
     secp256k1_frost_signature_share signature_shares[3];
@@ -2126,7 +2126,7 @@ void test_secp256k1_frost_aggregate_null_keypair(void) {
 void test_secp256k1_frost_aggregate_null_pubkeys(void) {
     secp256k1_context *sign_ctx;
     unsigned char signature[64];
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     secp256k1_frost_keypair keypair;
     secp256k1_frost_pubkey *public_keys = NULL;
     secp256k1_frost_signature_share signature_shares[3];
@@ -2156,7 +2156,7 @@ void test_secp256k1_frost_aggregate_null_pubkeys(void) {
 void test_secp256k1_frost_aggregate_null_signing_commitments(void) {
     secp256k1_context *sign_ctx;
     unsigned char signature[64];
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     secp256k1_frost_keypair keypair;
     secp256k1_frost_pubkey public_keys[3];
     secp256k1_frost_signature_share signature_shares[3];
@@ -2186,7 +2186,7 @@ void test_secp256k1_frost_aggregate_null_signing_commitments(void) {
 void test_secp256k1_frost_aggregate_null_signature_shares(void) {
     secp256k1_context *sign_ctx;
     unsigned char signature[64];
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     secp256k1_frost_keypair keypair;
     secp256k1_frost_pubkey public_keys[3];
     secp256k1_frost_signature_share *signature_shares = NULL;
@@ -2224,7 +2224,7 @@ void test_secp256k1_frost_aggregate_with_more_participants_than_max_to_be_invali
     secp256k1_frost_pubkey public_keys[3];
 
     uint32_t index;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     unsigned char binding_seed[32] = {0};
     unsigned char hiding_seed[32] = {0};
     secp256k1_frost_signature_share signature_shares[3];
@@ -2302,7 +2302,7 @@ void test_secp256k1_frost_aggregate_with_few_signature_share_to_be_invalid(void)
     secp256k1_frost_pubkey public_keys[3];
 
     uint32_t index;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     unsigned char binding_seed[32] = {0};
     unsigned char hiding_seed[32] = {0};
     secp256k1_frost_signature_share signature_shares[3];
@@ -2385,7 +2385,7 @@ void test_secp256k1_frost_aggregate_with_invalid_signature_share_to_be_invalid(v
     secp256k1_frost_pubkey public_keys[3];
 
     uint32_t index;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     unsigned char binding_seed[32] = {0};
     unsigned char hiding_seed[32] = {0};
     secp256k1_frost_signature_share signature_shares[3];
@@ -2465,7 +2465,7 @@ void test_secp256k1_frost_aggregate_with_invalid_group_key_to_be_invalid(void) {
     secp256k1_frost_pubkey public_keys[3];
 
     uint32_t index;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     unsigned char binding_seed[32] = {0};
     unsigned char hiding_seed[32] = {0};
     secp256k1_frost_signature_share signature_shares[3];
@@ -2543,7 +2543,7 @@ void test_secp256k1_frost_verify_with_invalid_group_key_to_be_invalid(void) {
     secp256k1_frost_pubkey public_keys[3];
 
     uint32_t index;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     unsigned char binding_seed[32] = {0};
     unsigned char hiding_seed[32] = {0};
     secp256k1_frost_signature_share signature_shares[3];
@@ -2628,8 +2628,8 @@ void test_secp256k1_frost_dkg_sign_aggregate_verify_to_be_valid(void) {
     secp256k1_frost_keypair keypairs[3];
     secp256k1_frost_pubkey public_keys[3];
     uint32_t index;
-    const unsigned char context[4] = "test";
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char context[4] = {'t', 'e', 's', 't'};
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     unsigned char binding_seed[32] = {0};
     unsigned char hiding_seed[32] = {0};
     secp256k1_frost_signature_share signature_shares[3];
@@ -2738,8 +2738,8 @@ void test_secp256k1_frost_dkg_sign_aggregate_verify_more_parts_to_be_valid(void)
     secp256k1_frost_keypair keypairs[10];
     secp256k1_frost_pubkey public_keys[10];
     uint32_t index;
-    const unsigned char context[4] = "test";
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char context[4] = {'t', 'e', 's', 't'};
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     unsigned char binding_seed[32] = {0};
     unsigned char hiding_seed[32] = {0};
     secp256k1_frost_signature_share signature_shares[10];
@@ -2943,7 +2943,7 @@ void test_secp256k1_frost_verify_to_be_valid(void) {
     secp256k1_gej pubkey;
     secp256k1_context *test_ctx;
     int result;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     unsigned char serialized64[64];
     secp256k1_frost_signature signature;
     secp256k1_frost_keypair keypair;
@@ -2973,7 +2973,7 @@ void test_secp256k1_frost_verify_to_be_valid(void) {
 void test_secp256k1_frost_verify_null_secp_context(void) {
     secp256k1_context *test_ctx = NULL;
     int result;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     unsigned char serialized64[64] = {0};
     secp256k1_frost_pubkey pubkey;
 
@@ -2988,7 +2988,7 @@ void test_secp256k1_frost_verify_null_secp_context(void) {
 void test_secp256k1_frost_verify_null_signature(void) {
     secp256k1_context *test_ctx;
     int result;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     unsigned char *serialized64 = NULL;
     secp256k1_frost_pubkey pubkey;
 
@@ -3024,7 +3024,7 @@ void test_secp256k1_frost_verify_null_message(void) {
 void test_secp256k1_frost_verify_null_pubkey(void) {
     secp256k1_context *test_ctx;
     int result;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     unsigned char serialized64[64] = {0};
     secp256k1_frost_pubkey *pubkey = NULL;
 
@@ -3046,7 +3046,7 @@ void test_secp256k1_frost_verify_to_be_invalid(void) {
     secp256k1_gej pubkey;
     secp256k1_context *test_ctx;
     int result;
-    const unsigned char msg32[32] = "zsdW0tL5jv9d1SZsIOUiDIIwWX7n6rgg";
+    const unsigned char msg32[32] = {'z', 's', 'd', 'W', '0', 't', 'L', '5', 'j', 'v', '9', 'd', '1', 'S', 'Z', 's', 'I', 'O', 'U', 'i', 'D', 'I', 'I', 'w', 'W', 'X', '7', 'n', '6', 'r', 'g', 'g'};
     unsigned char serialized64[64];
     secp256k1_frost_signature signature;
     secp256k1_frost_keypair keypair;

--- a/src/modules/schnorrsig/main_impl.h
+++ b/src/modules/schnorrsig/main_impl.h
@@ -45,7 +45,7 @@ static void secp256k1_nonce_function_bip340_sha256_tagged_aux(secp256k1_sha256 *
 
 /* algo argument for nonce_function_bip340 to derive the nonce exactly as stated in BIP-340
  * by using the correct tagged hash function. */
-static const unsigned char bip340_algo[13] = "BIP0340/nonce";
+static const unsigned char bip340_algo[] = {'B', 'I', 'P', '0', '3', '4', '0', '/', 'n', 'o', 'n', 'c', 'e'};
 
 static const unsigned char schnorrsig_extraparams_magic[4] = SECP256K1_SCHNORRSIG_EXTRAPARAMS_MAGIC;
 

--- a/src/modules/schnorrsig/tests_impl.h
+++ b/src/modules/schnorrsig/tests_impl.h
@@ -21,9 +21,9 @@ static void nonce_function_bip340_bitflip(unsigned char **args, size_t n_flip, s
 }
 
 static void run_nonce_function_bip340_tests(void) {
-    unsigned char tag[13] = "BIP0340/nonce";
-    unsigned char aux_tag[11] = "BIP0340/aux";
-    unsigned char algo[13] = "BIP0340/nonce";
+    unsigned char tag[] = {'B', 'I', 'P', '0', '3', '4', '0', '/', 'n', 'o', 'n', 'c', 'e'};
+    unsigned char aux_tag[] = {'B', 'I', 'P', '0', '3', '4', '0', '/', 'a', 'u', 'x'};
+    unsigned char algo[] = {'B', 'I', 'P', '0', '3', '4', '0', '/', 'n', 'o', 'n', 'c', 'e'};
     size_t algolen = sizeof(algo);
     secp256k1_sha256 sha;
     secp256k1_sha256 sha_optimized;
@@ -193,7 +193,7 @@ static void test_schnorrsig_api(void) {
 /* Checks that hash initialized by secp256k1_schnorrsig_sha256_tagged has the
  * expected state. */
 static void test_schnorrsig_sha256_tagged(void) {
-    unsigned char tag[17] = "BIP0340/challenge";
+    unsigned char tag[] = {'B', 'I', 'P', '0', '3', '4', '0', '/', 'c', 'h', 'a', 'l', 'l', 'e', 'n', 'g', 'e'};
     secp256k1_sha256 sha;
     secp256k1_sha256 sha_optimized;
 
@@ -841,7 +841,7 @@ static void test_schnorrsig_sign(void) {
     unsigned char sk[32];
     secp256k1_xonly_pubkey pk;
     secp256k1_keypair keypair;
-    const unsigned char msg[32] = "this is a msg for a schnorrsig..";
+    const unsigned char msg[] = {'t', 'h', 'i', 's', ' ', 'i', 's', ' ', 'a', ' ', 'm', 's', 'g', ' ', 'f', 'o', 'r', ' ', 'a', ' ', 's', 'c', 'h', 'n', 'o', 'r', 'r', 's', 'i', 'g', '.', '.'};
     unsigned char sig[64];
     unsigned char sig2[64];
     unsigned char zeros64[64] = { 0 };

--- a/src/testrand_impl.h
+++ b/src/testrand_impl.h
@@ -18,7 +18,7 @@
 static uint64_t secp256k1_test_state[4];
 
 SECP256K1_INLINE static void secp256k1_testrand_seed(const unsigned char *seed16) {
-    static const unsigned char PREFIX[19] = "secp256k1 test init";
+    static const unsigned char PREFIX[] = {'s', 'e', 'c', 'p', '2', '5', '6', 'k', '1', ' ', 't', 'e', 's', 't', ' ', 'i', 'n', 'i', 't'};
     unsigned char out32[32];
     secp256k1_sha256 hash;
     int i;


### PR DESCRIPTION
Let's bump the frost-specific CI toolchain to fedora 42, gcc 15.1.

Moreover, before this change `tests-for-windows.yml` had to dance around a bug in coreutils 9.5 (the support for `cp --update=none-fail` is broken there). Fedora 42 moves to coreutils 9.6 and we can revert back the hack.

The CI from upstream stays the same.
