### PR TITLE
ci: prefix with "frost-" all workflows not coming from upstream

### DIFF
--- a/.github/workflows/frost-build-with-cmake.yml
+++ b/.github/workflows/frost-build-with-cmake.yml
@@ -1,4 +1,4 @@
-name: Build using CMake
+name: "FROST: build using CMake"
 
 on:
   push:

--- a/.github/workflows/frost-check-header.yml
+++ b/.github/workflows/frost-check-header.yml
@@ -1,4 +1,4 @@
-name: Check that frost header can be precompiled
+name: "FROST: check that FROST header can be precompiled"
 
 on:
   push:

--- a/.github/workflows/frost-functional-tests.yml
+++ b/.github/workflows/frost-functional-tests.yml
@@ -1,4 +1,4 @@
-name: Functional tests, gcc14
+name: "FROST: functional tests (with and without coverage analysis)"
 
 # In secp256k1 some assertions are not exactly equal when coverage is enabled
 # and when it is not. Hence, it is better to run the two cases separately.

--- a/.github/workflows/frost-on-windows.yml
+++ b/.github/workflows/frost-on-windows.yml
@@ -1,4 +1,4 @@
-name: Build for Windows with autotools and CMake. Run functional tests and frost example under Wine
+name: "FROST: build for Windows with autotools and CMake. Run functional tests and example under Wine"
 
 on:
   push:

--- a/.github/workflows/frost-tests-and-examples-under-valgrind.yml
+++ b/.github/workflows/frost-tests-and-examples-under-valgrind.yml
@@ -1,4 +1,4 @@
-name: Run FROST tests and example under Valgrind
+name: "FROST: run tests and example under Valgrind"
 
 on:
   push:

--- a/.github/workflows/frost-verify-version-consistency.yml
+++ b/.github/workflows/frost-verify-version-consistency.yml
@@ -1,4 +1,4 @@
-name: Check that the version numbers contained in configure.ac and CMakeLists.txt are consistent with each other
+name: "FROST: check that the version numbers contained in configure.ac and CMakeLists.txt are consistent with each other"
 
 on:
   push:


### PR DESCRIPTION
We are a fork: it makes sense to make easily distinguishable the contributions that do not come from upstream.

No functional changes.