### PR TITLE
fix warning issued by clang22

### DIFF
--- a/src/modules/frost/main_impl.h
+++ b/src/modules/frost/main_impl.h
@@ -852,7 +852,7 @@ static SECP256K1_WARN_UNUSED_RESULT int compute_group_commitment(/* out */ secp2
     secp256k1_gej_set_infinity(group_commitment);
 
     for (index = 0; index < num_signers; index++) {
-        secp256k1_scalar *rho_i;
+        secp256k1_scalar *rho_i = NULL;
         secp256k1_gej partial;
         int found;
         const secp256k1_frost_nonce_commitment *commitment;
@@ -1249,7 +1249,7 @@ static SECP256K1_WARN_UNUSED_RESULT int verify_signature_share(const secp256k1_c
     secp256k1_gej signer_pubkey;
     secp256k1_gej partial, commitment_i, hiding_cmt, binding_cmt;
     secp256k1_scalar lambda_i;
-    secp256k1_scalar *matching_rho_i;
+    secp256k1_scalar *matching_rho_i = NULL;
     uint32_t index;
     int found;
 


### PR DESCRIPTION
The CI was failing due to a warning issued by clang-22.

Instructions to replicate the problem locally on Debian 13 Trixie (in a container or via [Distrobox](https://distrobox.it/)):

Optionally: use Distrobox to create an ephemeral Debian environment:
```
distrobox create --image debian --name debian
distrobox enter debian
```

prerequisite: install clang-snapshot (22 as of today). Instructions taken from `linux-debian.Dockerfile`:
```
# Setup GPG keys of LLVM repository
apt update
apt install --no-install-recommends -y wget
wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
# Add repository for this Debian release
. /etc/os-release
echo "deb http://apt.llvm.org/${VERSION_CODENAME} llvm-toolchain-${VERSION_CODENAME} main" >> /etc/apt/sources.list
apt update
# Determine the version number of the LLVM development branch
LLVM_VERSION=$(apt-cache search --names-only '^clang-[0-9]+$' | sort -V | tail -1 | cut -f1 -d" " | cut -f2 -d"-" )
# Install
apt install --no-install-recommends -y "clang-${LLVM_VERSION}"
# Create symlink
ln -s "/usr/bin/clang-${LLVM_VERSION}" /usr/bin/clang-snapshot
```

Configuration of the source tree:
```
export CC=clang-snapshot
./autogen.sh
./configure \
    --enable-experimental=yes
    --with-test-override-wide-multiply=int64
    --with-asm=no
    --with-ecmult-window=15
    --with-ecmult-gen-kb=86
    --enable-module-ecdh=yes
    --enable-module-recovery=no
    --enable-module-ellswift=yes
    --enable-module-extrakeys=yes
    --enable-module-schnorrsig=yes
    --enable-module-frost=yes
    --enable-examples=yes
    --enable-ctime-tests=yes
    --with-valgrind=yes
```

Trigger the error:
```
make
[...]
In file included from src/secp256k1.c:839:
src/modules/frost/main_impl.h:878:58: warning: variable 'rho_i' may be uninitialized when used here [-Wconditional-uninitialized]
  878 |         secp256k1_gej_mul_scalar(&partial, &binding_cmt, rho_i);
      |                                                          ^~~~~
src/modules/frost/main_impl.h:855:32: note: initialize the variable 'rho_i' to silence this warning
  855 |         secp256k1_scalar *rho_i;
      |                                ^
      |                                 = NULL
src/modules/frost/main_impl.h:1308:54: warning: variable 'matching_rho_i' may be uninitialized when used here [-Wconditional-uninitialized]
 1308 |     secp256k1_gej_mul_scalar(&partial, &binding_cmt, matching_rho_i);
      |                                                      ^~~~~~~~~~~~~~
src/modules/frost/main_impl.h:1252:37: note: initialize the variable 'matching_rho_i' to silence this warning
 1252 |     secp256k1_scalar *matching_rho_i;
      |                                     ^
      |                                      = NULL
2 warnings generated.
[...more errors...]
```
