### PR TITLE
enable frost everywhere in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,21 +73,21 @@ jobs:
       fail-fast: false
       matrix:
         configuration:
-          - env_vars: { WIDEMUL: 'int64',  RECOVERY: 'yes' }
+          - env_vars: { WIDEMUL: 'int64',  RECOVERY: 'yes',                                                                         EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
           - env_vars: { WIDEMUL: 'int64',                   ECDH: 'yes', EXTRAKEYS: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes',      EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
-          - env_vars: { WIDEMUL: 'int128' }
+          - env_vars: { WIDEMUL: 'int128',                                                                                          EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
           - env_vars: { WIDEMUL: 'int128_struct',                                                             ELLSWIFT: 'yes',      EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
           - env_vars: { WIDEMUL: 'int128', RECOVERY: 'yes',              EXTRAKEYS: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes',      EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
           - env_vars: { WIDEMUL: 'int128',                  ECDH: 'yes', EXTRAKEYS: 'yes', SCHNORRSIG: 'yes',                       EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
           - env_vars: { WIDEMUL: 'int128', ASM: 'x86_64',                                                     ELLSWIFT: 'yes',      EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
           - env_vars: {                    RECOVERY: 'yes',              EXTRAKEYS: 'yes', SCHNORRSIG: 'yes',                       EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
           - env_vars: { CTIMETESTS: 'no',  RECOVERY: 'yes', ECDH: 'yes', EXTRAKEYS: 'yes', SCHNORRSIG: 'yes', CPPFLAGS: '-DVERIFY', EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
-          - env_vars: { BUILD: 'distcheck', WITH_VALGRIND: 'no', CTIMETESTS: 'no', BENCH: 'no' }
-          - env_vars: { CPPFLAGS: '-DDETERMINISTIC' }
-          - env_vars: { CFLAGS: '-O0', CTIMETESTS: 'no' }
+          - env_vars: { BUILD: 'distcheck', WITH_VALGRIND: 'no', CTIMETESTS: 'no', BENCH: 'no',                                     EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
+          - env_vars: { CPPFLAGS: '-DDETERMINISTIC',                                                                                EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
+          - env_vars: { CFLAGS: '-O0', CTIMETESTS: 'no',                                                                            EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
           - env_vars: { CFLAGS: '-O1',     RECOVERY: 'yes', ECDH: 'yes', EXTRAKEYS: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes',      EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
-          - env_vars: { ECMULTGENKB: 2, ECMULTWINDOW: 2 }
-          - env_vars: { ECMULTGENKB: 86, ECMULTWINDOW: 4 }
+          - env_vars: { ECMULTGENKB: 2, ECMULTWINDOW: 2,                                                                            EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
+          - env_vars: { ECMULTGENKB: 86, ECMULTWINDOW: 4,                                                                           EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
         cc:
           - 'gcc'
           - 'clang'
@@ -633,15 +633,15 @@ jobs:
       fail-fast: false
       matrix:
         env_vars:
-          - { WIDEMUL: 'int64',  RECOVERY: 'yes', ECDH: 'yes', EXTRAKEYS: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes' , EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
-          - { WIDEMUL: 'int128_struct', ECMULTGENKB: 2, ECMULTWINDOW: 4 }
-          - { WIDEMUL: 'int128',                  ECDH: 'yes', EXTRAKEYS: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes' , EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
-          - { WIDEMUL: 'int128', RECOVERY: 'yes' }
-          - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', EXTRAKEYS: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
-          - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', EXTRAKEYS: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', CC: 'gcc', EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
+          - { WIDEMUL: 'int64',  RECOVERY: 'yes', ECDH: 'yes', EXTRAKEYS: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes' ,                                                                                 EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
+          - { WIDEMUL: 'int128_struct', ECMULTGENKB: 2, ECMULTWINDOW: 4,                                                                                                                              EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
+          - { WIDEMUL: 'int128',                  ECDH: 'yes', EXTRAKEYS: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes' ,                                                                                 EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
+          - { WIDEMUL: 'int128', RECOVERY: 'yes',                                                                                                                                                     EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
+          - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', EXTRAKEYS: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes',                                                                                  EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
+          - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', EXTRAKEYS: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', CC: 'gcc',                                                                       EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
           - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', EXTRAKEYS: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes',            WRAPPER_CMD: 'valgrind --error-exitcode=42', SECP256K1_TEST_ITERS: 2, EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
           - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', EXTRAKEYS: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', CC: 'gcc', WRAPPER_CMD: 'valgrind --error-exitcode=42', SECP256K1_TEST_ITERS: 2, EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
-          - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', EXTRAKEYS: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', CPPFLAGS: '-DVERIFY', CTIMETESTS: 'no', EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
+          - { WIDEMUL: 'int128', RECOVERY: 'yes', ECDH: 'yes', EXTRAKEYS: 'yes', SCHNORRSIG: 'yes', ELLSWIFT: 'yes', CPPFLAGS: '-DVERIFY', CTIMETESTS: 'no',                                          EXPERIMENTAL: 'yes', FROST: 'yes' } # FROST_SPECIFIC: added EXPERIMENTAL and FROST. Both set to 'yes'
           - BUILD: 'distcheck'
 
     steps:


### PR DESCRIPTION
Possibly due to oversights, not all possible CI combinations were enabling frost in the CI.

This PR attempts to systematically enable it, in order to facilitate catching future errors.
