### PR TITLE
refactor secp256k1_frost_pubkey_save() and secp256k1_frost_keygen_with_dealer(), fix potential leaks

### DIFF
--- a/src/modules/frost/main_impl.h
+++ b/src/modules/frost/main_impl.h
@@ -693,10 +693,12 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_frost_keygen_dkg_begin(
     }
     if (generate_shares_with_random_polynomial(ctx, vss_commitments, secret_key_shares, num_participants,
                                                threshold, generator_index, &secret) == 0) {
+        secp256k1_scalar_clear(&secret);
         return 0;
     }
 
     if (initialize_random_scalar(&r) == 0) {
+        secp256k1_scalar_clear(&secret);
         return 0;
     }
     secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &s_pub, &secret);


### PR DESCRIPTION
This series reorganizes the work that @matteonardelli has done in 6725845f44ff8721011b9c626236c7bd83f381cb on **v0.6.0**.

The PR:
- rebases the changes, from **v0.6.0** to **v0.5.1**;
- prevents a potential memory leak in `secp256k1_frost_keygen_with_dealer()`;
- prevents a potential secret leak in `secp256k1_frost_keygen_with_dealer()` and `secp256k1_frost_keygen_dkg_begin()`;
- applies modifications from #51;
- splits the changes in distinct commits.
