### PR TITLE
ci: also test cmake builds with Valgrind

### DIFF
--- a/.github/workflows/frost-valgrind-autotools.yml
+++ b/.github/workflows/frost-valgrind-autotools.yml
@@ -1,4 +1,4 @@
-name: "FROST: run tests and example under Valgrind"
+name: "FROST: run tests and examples under Valgrind (autotools)"
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  tests-and-examples-under-valgrind:
+  frost-valgrind-autotools:
     runs-on: ubuntu-24.04
     # Use fedora:42 to compile using gcc-15.1
     container:

--- a/.github/workflows/frost-valgrind-cmake.yml
+++ b/.github/workflows/frost-valgrind-cmake.yml
@@ -1,0 +1,62 @@
+name: "FROST: run tests and examples under Valgrind (CMake)"
+
+on:
+  push:
+    branches:
+      - frost
+  pull_request:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  frost-valgrind-cmake:
+    runs-on: ubuntu-24.04
+    # Use fedora:42 to compile using gcc-15.1
+    container:
+      image: fedora:42
+    steps:
+      - name: Install build dependencies and Valgrind
+        run: |
+          dnf install -y \
+              cmake \
+              gcc \
+              valgrind
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Build with CMake (only enabling FROST, tests and examples)
+        run: |
+          mkdir build
+          cd build
+          # please keep "-DSECP256K1_*" options sorted via "LC_ALL=C sort"
+          cmake \
+              -DCMAKE_C_FLAGS="-Werror" \
+              -DCMAKE_BUILD_TYPE="Release" \
+              -DSECP256K1_BUILD_BENCHMARK=OFF \
+              -DSECP256K1_BUILD_CTIME_TESTS=OFF \
+              -DSECP256K1_BUILD_EXAMPLES=ON \
+              -DSECP256K1_BUILD_EXHAUSTIVE_TESTS=OFF \
+              -DSECP256K1_BUILD_TESTS=ON \
+              -DSECP256K1_ENABLE_MODULE_ECDH=OFF \
+              -DSECP256K1_ENABLE_MODULE_ELLSWIFT=OFF \
+              -DSECP256K1_ENABLE_MODULE_EXTRAKEYS=OFF \
+              -DSECP256K1_ENABLE_MODULE_FROST=ON \
+              -DSECP256K1_ENABLE_MODULE_RECOVERY=OFF \
+              -DSECP256K1_ENABLE_MODULE_SCHNORRSIG=OFF \
+              -DSECP256K1_EXPERIMENTAL=ON \
+              ..
+          make -j
+      - name: run the FROST example under Valgrind
+        run: |
+          valgrind \
+              --show-error-list=yes \
+              --leak-check=yes \
+              --error-exitcode=17 \
+              "${GITHUB_WORKSPACE}/build/examples/frost_example"
+      - name: run the FROST tests under Valgrind
+        run: |
+          valgrind \
+              --show-error-list=yes \
+              --leak-check=yes \
+              --error-exitcode=17 \
+              "${GITHUB_WORKSPACE}/build/src/tests"


### PR DESCRIPTION
A recent test showed us that there are errors that we are able to trigger when building with CMake, but not with autotools.