### PR TITLE
release v0.5.1-frost-2

### DIFF
--- a/CHANGELOG-FROST.md
+++ b/CHANGELOG-FROST.md
@@ -1,0 +1,24 @@
+# Changelog - FROST module
+
+## [0.5.1-frost-2] - 2026-02-18
+
+#### Added
+ - benchmark for FROST module
+ - ci: also test CMake builds under Valgrind
+ - ci: check version consistency among Autotools and CMake builds
+
+#### Changed
+ - improved documentation of the public FROST API in `include/secp256k1_frost.h`
+ - use an equivalent but more efficient formula in `secp256k1_frost_verify()`
+ - ci: added the possibility of manually triggering a CI run
+ - canonicalized parameter order in internal functions
+ - use uniform parameter names in the module
+ - introduced a return code for `secp256k1_frost_gej_serialize_compact()`
+ - clear temporaries in `secp256k1_frost_keygen_dkg_begin()` and `secp256k1_frost_gej_serialize_compact()`
+ - removed redundant code in `secp256k1_frost_aggregate()`, `encode_group_commitments()`, `generate_dkg_challenge()`
+
+#### Fixed
+ - fixed compilation warning under clang-22
+ - fix documentation inconsistencies
+
+[0.5.1-frost-2]: https://github.com/bancaditalia/secp256k1-frost/compare/v0.5.1-frost-1...v0.5.1-frost-2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(libsecp256k1
   # The package (a.k.a. release) version is based on semantic versioning 2.0.0 of
   # the API. All changes in experimental modules are treated as
   # backwards-compatible and therefore at most increase the minor version.
-  VERSION 0.5.1.1 # FROST_SPECIFIC: the fourth number must be equal to the value of _PKG_VERSION_FROST_BUILD in configure.ac
+  VERSION 0.5.1.2 # FROST_SPECIFIC: the fourth number must be equal to the value of _PKG_VERSION_FROST_BUILD in configure.ac
   DESCRIPTION "Optimized C library for ECDSA signatures and secret/public key operations on curve secp256k1, with support for FROST signature scheme" # FROST_SPECIFIC
   HOMEPAGE_URL "https://github.com/bancaditalia/secp256k1-frost" # FROST_SPECIFIC: replaced URIs with those of Bank of Italy's fork.
   LANGUAGES C

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_PREREQ([2.60])
 define(_PKG_VERSION_MAJOR, 0)
 define(_PKG_VERSION_MINOR, 5)
 define(_PKG_VERSION_PATCH, 1)
-define(_PKG_VERSION_FROST_BUILD, 1) # FROST_SPECIFIC: this field controls the final digit in the version identifier "MAJOR.MINOR.BUILD-frost-FROST_BUILD". WARNING: this number should be equal to the fourth digit of project(... VERSION ...) in CMakeLists.txt
+define(_PKG_VERSION_FROST_BUILD, 2) # FROST_SPECIFIC: this field controls the final digit in the version identifier "MAJOR.MINOR.BUILD-frost-FROST_BUILD". WARNING: this number should be equal to the fourth digit of project(... VERSION ...) in CMakeLists.txt
 define(_PKG_VERSION_IS_RELEASE, true)
 
 # The library version is based on libtool versioning of the ABI. The set of


### PR DESCRIPTION
This version backports on top of **v0.5.1-frost-1** most of the preparatory changes realized while implementing the RFC9591 compliance, and that did not require later versions of the library.

Releasing them on 0.5.1 benefits the older version of the library and reduces the amount of changes that will be needed for RFC9591.

#### Added
 - benchmark for FROST module
 - ci: also test CMake builds under Valgrind
 - ci: check version consistency among Autotools and CMake builds

#### Changed
 - improved documentation of the public FROST API in `include/secp256k1_frost.h`
 - use an equivalent but more efficient formula in `secp256k1_frost_verify()`
 - ci: added the possibility of manually triggering a CI run
 - canonicalized parameter order in internal functions
 - use uniform parameter names in the module
 - introduced a return code for `secp256k1_frost_gej_serialize_compact()`
 - clear temporaries in `secp256k1_frost_keygen_dkg_begin()` and `secp256k1_frost_gej_serialize_compact()`
 - removed redundant code in `secp256k1_frost_aggregate()`, `encode_group_commitments()`, `generate_dkg_challenge()`

#### Fixed
 - fixed compilation warning under clang-22
 - fix documentation inconsistencies

Full changes can be generated via this URL: https://github.com/bancaditalia/secp256k1-frost/compare/v0.5.1-frost-1...v0.5.1-frost-2