### PR TITLE
ci: update base image fedora 42 -> fedora 43, update actions/checkout v4 -> v6

### DIFF
--- a/.github/workflows/frost-build-with-cmake.yml
+++ b/.github/workflows/frost-build-with-cmake.yml
@@ -20,7 +20,7 @@ jobs:
           dnf install -y \
               cmake \
               gcc
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Build with CMake

--- a/.github/workflows/frost-build-with-cmake.yml
+++ b/.github/workflows/frost-build-with-cmake.yml
@@ -11,9 +11,9 @@ on:
 jobs:
   build-with-cmake:
     runs-on: ubuntu-24.04
-    # Use fedora:42 to compile using gcc-15.1
+    # Use fedora:43 to compile using gcc-15.2
     container:
-      image: fedora:42
+      image: fedora:43
     steps:
       - name: Install build dependencies
         run: |

--- a/.github/workflows/frost-check-header.yml
+++ b/.github/workflows/frost-check-header.yml
@@ -11,9 +11,9 @@ on:
 jobs:
   precompile_frost_header:
     runs-on: ubuntu-24.04
-    # Use fedora:42 to compile using gcc-15.1
+    # Use fedora:43 to compile using gcc-15.2
     container:
-      image: fedora:42
+      image: fedora:43
     steps:
       - name: Install build dependencies
         run: |

--- a/.github/workflows/frost-check-header.yml
+++ b/.github/workflows/frost-check-header.yml
@@ -20,7 +20,7 @@ jobs:
           dnf install -y \
               g++ \
               gcc
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Check that frost header can be precompiled (C)

--- a/.github/workflows/frost-functional-tests.yml
+++ b/.github/workflows/frost-functional-tests.yml
@@ -29,7 +29,7 @@ jobs:
               gcovr \
               libtool \
               pkg-config
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Run autogen

--- a/.github/workflows/frost-functional-tests.yml
+++ b/.github/workflows/frost-functional-tests.yml
@@ -14,9 +14,9 @@ on:
 jobs:
   functional-tests:
     runs-on: ubuntu-24.04
-    # Use fedora:42 to compile using gcc-15.1
+    # Use fedora:43 to compile using gcc-15.2
     container:
-      image: fedora:42
+      image: fedora:43
     steps:
       - name: Install build dependencies
         run: |

--- a/.github/workflows/frost-on-windows.yml
+++ b/.github/workflows/frost-on-windows.yml
@@ -35,7 +35,7 @@ jobs:
         run: echo HOME=/root >> "$GITHUB_ENV"
       - name: set up wine 2
         run: wine64 winecfg /v win11
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: "Autotools: run autogen"

--- a/.github/workflows/frost-on-windows.yml
+++ b/.github/workflows/frost-on-windows.yml
@@ -12,7 +12,7 @@ jobs:
   example-and-tests-mingw-autotools-cmake:
     runs-on: ubuntu-24.04
     container:
-      image: fedora:42
+      image: fedora:43
     steps:
       - name: Install build dependencies
         run: |
@@ -112,7 +112,7 @@ jobs:
           #
           # "--update=none-fail" did not work on coreutils 9.5 (Fedora 41) due
           # to a bug. It required a workaround that is no longer necessary with
-          # coreutils 9.6 (Fedora 42).
+          # coreutils 9.6 (Fedora 42 or later).
           cp --update=none-fail "${GITHUB_WORKSPACE}/build/examples/frost_example.exe" "${GITHUB_WORKSPACE}/build/src"
           wine "${GITHUB_WORKSPACE}/build/src/frost_example.exe"
       - name: "Cmake: run frost benchmark via Wine (10 iterations)"

--- a/.github/workflows/frost-valgrind-autotools.yml
+++ b/.github/workflows/frost-valgrind-autotools.yml
@@ -11,9 +11,9 @@ on:
 jobs:
   frost-valgrind-autotools:
     runs-on: ubuntu-24.04
-    # Use fedora:42 to compile using gcc-15.1
+    # Use fedora:43 to compile using gcc-15.2
     container:
-      image: fedora:42
+      image: fedora:43
     steps:
       - name: Install build dependencies and Valgrind
         run: |

--- a/.github/workflows/frost-valgrind-autotools.yml
+++ b/.github/workflows/frost-valgrind-autotools.yml
@@ -25,7 +25,7 @@ jobs:
               libtool \
               pkg-config \
               valgrind
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: prepare the build (only enabling FROST, tests, examples and benchmark)

--- a/.github/workflows/frost-valgrind-cmake.yml
+++ b/.github/workflows/frost-valgrind-cmake.yml
@@ -21,7 +21,7 @@ jobs:
               cmake \
               gcc \
               valgrind
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Build with CMake (only enabling FROST, tests, examples and benchmark)

--- a/.github/workflows/frost-valgrind-cmake.yml
+++ b/.github/workflows/frost-valgrind-cmake.yml
@@ -11,9 +11,9 @@ on:
 jobs:
   frost-valgrind-cmake:
     runs-on: ubuntu-24.04
-    # Use fedora:42 to compile using gcc-15.1
+    # Use fedora:43 to compile using gcc-15.2
     container:
-      image: fedora:42
+      image: fedora:43
     steps:
       - name: Install build dependencies and Valgrind
         run: |

--- a/.github/workflows/frost-verify-version-and-description-consistency.yml
+++ b/.github/workflows/frost-verify-version-and-description-consistency.yml
@@ -12,7 +12,7 @@ jobs:
   verify-version-and-description-consistency:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: check that the version numbers contained in configure.ac and CMakeLists.txt are consistent with each other, and that the project descriptions end with the same reference to Frost


### PR DESCRIPTION
Update the CI toolchain for our Frost specific workflows:

- Fedora **42** (gcc 15.1) -> **43** (gcc 15.2)
- https://github.com/actions/checkout: v4 -> v6